### PR TITLE
fixing compilation of the demo

### DIFF
--- a/binary/src/bin/demo.rs
+++ b/binary/src/bin/demo.rs
@@ -1,18 +1,20 @@
-use anyhow::Result;
-use pocketflow_core::{Flow, SharedStore};
-use agent_nexus::NexusNode;
 use agent_forge::ForgeNode;
-use config::{WorkerSlot, KEY_WORKER_SLOTS, KEY_TICKETS, Ticket, ACTION_WORK_ASSIGNED, ACTION_NO_WORK, ACTION_PR_OPENED, ACTION_FAILED, ACTION_EMPTY};
-use std::sync::Arc;
+use agent_nexus::NexusNode;
+use anyhow::Result;
+use config::{
+    Ticket, WorkerSlot, ACTION_EMPTY, ACTION_FAILED, ACTION_NO_WORK, ACTION_PR_OPENED,
+    ACTION_WORK_ASSIGNED, KEY_TICKETS, KEY_WORKER_SLOTS,
+};
+use dotenvy;
+use pocketflow_core::{Flow, SharedStore};
 use std::collections::HashMap;
+use std::sync::Arc;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
-use dotenvy;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
-    tracing_subscriber::fmt::init();
     // 1. Setup logging
     let subscriber = FmtSubscriber::builder()
         .with_max_level(Level::INFO)
@@ -27,7 +29,7 @@ async fn main() -> Result<()> {
     std::env::set_var("ANTHROPIC_API_URL", "http://localhost:8082"); // assume mock server if running, else we need a local mock
     std::env::set_var("GITHUB_MCP_CMD", "python3 scripts/mock_mcp.py");
     std::env::set_var("GITHUB_PERSONAL_ACCESS_TOKEN", "test-token");
-    
+
     // Ensure scripts/mock_claude.py is in PATH as 'claude'
     let repo_root = std::env::current_dir()?;
     let bin_dir = repo_root.join("target/debug/test_bin");
@@ -38,7 +40,7 @@ async fn main() -> Result<()> {
 
     // 3. Initialize Store
     let store = SharedStore::new_in_memory();
-    
+
     // Inject a sample ticket if list_issues is empty (our mock returns one, but let's be safe)
     let ticket = Ticket {
         id: "T-101".to_string(),
@@ -47,34 +49,53 @@ async fn main() -> Result<()> {
         priority: 1,
         branch: None,
     };
-    store.set(KEY_TICKETS, serde_json::json!(vec![ticket])).await;
+    store
+        .set(KEY_TICKETS, serde_json::json!(vec![ticket]))
+        .await;
 
     // 4. Build Nodes
-    let nexus = Arc::new(NexusNode::new(".agent/agents/nexus.agent.md", ".agent/registry.json"));
+    let nexus = Arc::new(NexusNode::new(
+        ".agent/agents/nexus.agent.md",
+        ".agent/registry.json",
+    ));
     let forge = Arc::new(ForgeNode::new("."));
 
     // 5. Build Flow
     let flow = Flow::new("nexus")
-        .add_node("nexus", nexus, vec![
-            (ACTION_WORK_ASSIGNED, "forge"),
-            (ACTION_NO_WORK,       "nexus"),
-            ("approve_command",    "forge"),
-            ("reject_command",     "nexus"),
-        ])
-        .add_node("forge", forge, vec![(ACTION_PR_OPENED, "nexus"), (ACTION_FAILED, "nexus"), (ACTION_EMPTY, "nexus"), ("suspended", "nexus")])
+        .add_node(
+            "nexus",
+            nexus,
+            vec![
+                (ACTION_WORK_ASSIGNED, "forge"),
+                (ACTION_NO_WORK, "nexus"),
+                ("approve_command", "forge"),
+                ("reject_command", "nexus"),
+            ],
+        )
+        .add_node(
+            "forge",
+            forge,
+            vec![
+                (ACTION_PR_OPENED, "nexus"),
+                (ACTION_FAILED, "nexus"),
+                (ACTION_EMPTY, "nexus"),
+                ("suspended", "nexus"),
+            ],
+        )
         .max_steps(5);
 
     // 6. Run Flow manually to show store updates
-    let mut current_node = "nexus".to_string();
+    let current_node = "nexus".to_string();
     for step in 0..5 {
         info!("--- STEP {}: Node {} ---", step, current_node);
-        
+
         // Print store BEFORE
-        let slots: HashMap<String, WorkerSlot> = store.get_typed(KEY_WORKER_SLOTS).await.unwrap_or_default();
+        let slots: HashMap<String, WorkerSlot> =
+            store.get_typed(KEY_WORKER_SLOTS).await.unwrap_or_default();
         info!("Worker Slots BEFORE: {:?}", slots);
 
         // Run the node once (logic simplified from Flow::run)
-        let action = if current_node == "nexus" {
+        let _action = if current_node == "nexus" {
             // We need to access the node directly, but Flow abstracts it.
             // For the demo, let's just use the flow.run but with tracing on.
             break; // We'll just use flow.run and let the background info logs show it
@@ -88,7 +109,8 @@ async fn main() -> Result<()> {
     flow.run(&store).await?;
 
     info!("Demo completed.");
-    let final_slots: HashMap<String, WorkerSlot> = store.get_typed(KEY_WORKER_SLOTS).await.unwrap_or_default();
+    let final_slots: HashMap<String, WorkerSlot> =
+        store.get_typed(KEY_WORKER_SLOTS).await.unwrap_or_default();
     info!("Final Worker Slots: {:?}", final_slots);
 
     Ok(())

--- a/binary/src/bin/real_test.rs
+++ b/binary/src/bin/real_test.rs
@@ -1,9 +1,8 @@
 use anyhow::Result;
-use pocketflow_core::{Flow, SharedStore, Action};
+use pocketflow_core::{Flow, SharedStore};
 use agent_nexus::NexusNode;
 use agent_forge::ForgeNode;
 use config::{KEY_WORKER_SLOTS, KEY_TICKETS, ACTION_WORK_ASSIGNED, ACTION_PR_OPENED, ACTION_FAILED, ACTION_NO_WORK};
-use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::info;
 

--- a/crates/agent-forge/src/lib.rs
+++ b/crates/agent-forge/src/lib.rs
@@ -1,14 +1,16 @@
 // crates/agent-forge/src/lib.rs
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use pocketflow_core::{BatchNode, SharedStore, Action};
-use config::{WorkerSlot, WorkerStatus, state::{KEY_WORKER_SLOTS, KEY_COMMAND_GATE, ACTION_PR_OPENED, ACTION_FAILED, ACTION_EMPTY}};
+use config::{
+    state::{ACTION_EMPTY, ACTION_FAILED, ACTION_PR_OPENED, KEY_COMMAND_GATE, KEY_WORKER_SLOTS},
+    WorkerSlot, WorkerStatus,
+};
+use pocketflow_core::{Action, BatchNode, SharedStore};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use tracing::{info, warn};
-use tokio::io;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ForgeStatus {
@@ -26,40 +28,58 @@ pub struct ForgeNode {
 
 impl ForgeNode {
     pub fn new(workspace_root: impl Into<PathBuf>) -> Self {
-        Self { workspace_root: workspace_root.into() }
+        Self {
+            workspace_root: workspace_root.into(),
+        }
     }
 }
 
 #[async_trait]
 impl BatchNode for ForgeNode {
-    fn name(&self) -> &str { "forge" }
+    fn name(&self) -> &str {
+        "forge"
+    }
 
     async fn prep_batch(&self, store: &SharedStore) -> Result<Vec<Value>> {
-        let slots: HashMap<String, WorkerSlot> = store
-            .get_typed(KEY_WORKER_SLOTS)
-            .await
-            .unwrap_or_default();
+        let slots: HashMap<String, WorkerSlot> =
+            store.get_typed(KEY_WORKER_SLOTS).await.unwrap_or_default();
 
-        let active_workers: Vec<Value> = slots.values()
-            .filter(|s| matches!(s.status, WorkerStatus::Assigned { .. } | WorkerStatus::Working { .. }))
+        let active_workers: Vec<Value> = slots
+            .values()
+            .filter(|s| {
+                matches!(
+                    s.status,
+                    WorkerStatus::Assigned { .. } | WorkerStatus::Working { .. }
+                )
+            })
             .map(|s| json!(s))
             .collect();
-        
+
         Ok(active_workers)
     }
 
     async fn exec_one(&self, item: Value) -> Result<Value> {
         let slot: WorkerSlot = serde_json::from_value(item)?;
         let worker_id = slot.id.clone();
-        
+
         let (ticket_id, issue_url) = match &slot.status {
-            WorkerStatus::Assigned { ticket_id, issue_url } => (ticket_id.clone(), issue_url.clone()),
-            WorkerStatus::Working { ticket_id, issue_url }  => (ticket_id.clone(), issue_url.clone()),
+            WorkerStatus::Assigned {
+                ticket_id,
+                issue_url,
+            } => (ticket_id.clone(), issue_url.clone()),
+            WorkerStatus::Working {
+                ticket_id,
+                issue_url,
+            } => (ticket_id.clone(), issue_url.clone()),
             _ => return Ok(json!({"outcome": "idle", "worker_id": worker_id})),
         };
 
         // Ensure worker dir exists
-        let worker_dir = self.workspace_root.join("forge").join("workers").join(&worker_id);
+        let worker_dir = self
+            .workspace_root
+            .join("forge")
+            .join("workers")
+            .join(&worker_id);
         if !worker_dir.exists() {
             tokio::fs::create_dir_all(&worker_dir).await?;
         }
@@ -91,17 +111,20 @@ impl BatchNode for ForgeNode {
             .args(["--print", "--output-format", "json"])
             .arg(&prompt)
             .current_dir(&worker_dir)
-            .env("ANTHROPIC_API_KEY", std::env::var("ANTHROPIC_API_KEY").unwrap_or_default())
+            .env(
+                "ANTHROPIC_API_KEY",
+                std::env::var("ANTHROPIC_API_KEY").unwrap_or_default(),
+            )
             .stdout(log_file)
             .stderr(log_file_err)
             .spawn()
             .map_err(|e| anyhow!("Failed to spawn Claude Code: {}", e))?;
 
-        // MONITORING: Since we redirected stdout/stderr to a file, we can't easily 
-        // monitor for "Dangerous command" strings in real-time within this process 
+        // MONITORING: Since we redirected stdout/stderr to a file, we can't easily
+        // monitor for "Dangerous command" strings in real-time within this process
         // without tailing the file. For now, we'll let it run and check the STATUS.json
         // or the log file afterwards.
-        
+
         let timeout_dur = std::time::Duration::from_secs(1800); // 30 minutes
 
         // 2. Wait for process
@@ -147,20 +170,12 @@ impl BatchNode for ForgeNode {
         }))
     }
 
-    async fn post_batch(
-        &self,
-        store: &SharedStore,
-        results: Vec<Result<Value>>,
-    ) -> Result<Action> {
-        let mut slots: HashMap<String, WorkerSlot> = store
-            .get_typed(KEY_WORKER_SLOTS)
-            .await
-            .unwrap_or_default();
+    async fn post_batch(&self, store: &SharedStore, results: Vec<Result<Value>>) -> Result<Action> {
+        let mut slots: HashMap<String, WorkerSlot> =
+            store.get_typed(KEY_WORKER_SLOTS).await.unwrap_or_default();
 
-        let mut command_gate: HashMap<String, Value> = store
-            .get_typed(KEY_COMMAND_GATE)
-            .await
-            .unwrap_or_default();
+        let mut command_gate: HashMap<String, Value> =
+            store.get_typed(KEY_COMMAND_GATE).await.unwrap_or_default();
 
         let mut all_success = true;
 
@@ -175,22 +190,31 @@ impl BatchNode for ForgeNode {
             };
             let worker_id = res["worker_id"].as_str().unwrap_or("");
             let ticket_id = res["ticket_id"].as_str().unwrap_or("");
-            let outcome   = res["outcome"].as_str().unwrap_or("failed");
+            let outcome = res["outcome"].as_str().unwrap_or("failed");
 
             if let Some(slot) = slots.get_mut(worker_id) {
                 match outcome {
                     "pr_opened" => {
-                        info!(worker = worker_id, ticket = ticket_id, "Work completed successfully");
-                        slot.status = WorkerStatus::Done { 
-                            ticket_id: ticket_id.to_string(), 
-                            outcome: outcome.to_string() 
+                        info!(
+                            worker = worker_id,
+                            ticket = ticket_id,
+                            "Work completed successfully"
+                        );
+                        slot.status = WorkerStatus::Done {
+                            ticket_id: ticket_id.to_string(),
+                            outcome: outcome.to_string(),
                         };
                     }
                     "suspended" => {
                         let reason = res["reason"].as_str().unwrap_or("unknown");
-                        info!(worker = worker_id, ticket = ticket_id, reason, "Work suspended for approval");
-                        slot.status = WorkerStatus::Suspended { 
-                            ticket_id: ticket_id.to_string(), 
+                        info!(
+                            worker = worker_id,
+                            ticket = ticket_id,
+                            reason,
+                            "Work suspended for approval"
+                        );
+                        slot.status = WorkerStatus::Suspended {
+                            ticket_id: ticket_id.to_string(),
                             reason: reason.to_string(),
                             issue_url: res["issue_url"].as_str().map(|s| s.to_string()),
                         };
@@ -199,7 +223,12 @@ impl BatchNode for ForgeNode {
                     }
                     "idle" => {}
                     _ => {
-                        warn!(worker = worker_id, ticket = ticket_id, outcome, "Work failed");
+                        warn!(
+                            worker = worker_id,
+                            ticket = ticket_id,
+                            outcome,
+                            "Work failed"
+                        );
                         slot.status = WorkerStatus::Idle;
                         all_success = false;
                     }
@@ -210,7 +239,9 @@ impl BatchNode for ForgeNode {
         store.set(KEY_WORKER_SLOTS, json!(slots)).await;
         store.set(KEY_COMMAND_GATE, json!(command_gate)).await;
 
-        let has_suspended = slots.values().any(|s| matches!(s.status, WorkerStatus::Suspended { .. }));
+        let has_suspended = slots
+            .values()
+            .any(|s| matches!(s.status, WorkerStatus::Suspended { .. }));
 
         if has_suspended {
             Ok(Action::new("suspended"))


### PR DESCRIPTION
**Fix: Tracing double-initialization and compilation warnings**

***Problem***
Running cargo run -p agent-team --bin demo crashed immediately with:

``Error: a global default trace dispatcher has already been set
This was caused by two competing tracing subscriber initializations in 
demo.rs``


1- ``tracing_subscriber::fmt::init()`` — set the global default
2- ``FmtSubscriber::builder()...set_global_default(subscriber)?`` — tried to set it a second time, causing the panic

**Changes**
**binary/src/bin/demo.rs**

- Removed the redundant tracing_subscriber::fmt::init() call; kept only the builder-based subscriber (more configurable, allows setting max_level)
- Fixed let mut current_node → let current_node (unused mut warning)
- Renamed action → _action (unused variable warning)

**crates/agent-forge/src/lib.rs**
Removed unused use tokio::io; import

**binary/src/bin/real_test.rs**

Removed unused imports Action and std::path::PathBuf
Result
cargo run -p agent-team --bin demo compiles and runs with zero warnings and tracing output works correctly.