### PR TITLE
fix(harness): properly link issues to PRs spawned by forge (#36)

### DIFF
--- a/crates/pair-harness/src/pair.rs
+++ b/crates/pair-harness/src/pair.rs
@@ -376,6 +376,7 @@ pub struct ForgeSentinelPair {
     last_sentinel_spawn_time: Option<Instant>,
     last_sentinel_failure: Option<SentinelFailureInfo>,
     ticket_id: String,
+    issue_number: u64,
     plan_approved: bool,
     final_approved: bool,
     contract_timeout: Option<TimeoutProfile>,
@@ -439,6 +440,7 @@ impl ForgeSentinelPair {
             last_sentinel_spawn_time: None,
             last_sentinel_failure: None,
             ticket_id: String::new(),
+            issue_number: 0,
             plan_approved: false,
             final_approved: false,
             contract_timeout: None,
@@ -465,6 +467,7 @@ impl ForgeSentinelPair {
 
         self.start_time = Instant::now();
         self.ticket_id = ticket.id.clone();
+        self.issue_number = ticket.issue_number;
 
         // Check if this is a resume with existing approved plan
         let contract_path = self.config.shared.join("CONTRACT.md");
@@ -1511,13 +1514,13 @@ impl ForgeSentinelPair {
             .await
     }
 
-    /// Spawn FORGE process for PR creation after final approval.
     async fn spawn_forge_for_pr(&mut self) -> Result<Child> {
         self.forge_spawn_time = Instant::now();
         self.process
             .spawn_forge_for_pr(
                 &self.config.pair_id,
                 &self.ticket_id,
+                self.issue_number,
                 &self.config.worktree,
                 &self.config.shared,
             )

--- a/crates/pair-harness/src/process.rs
+++ b/crates/pair-harness/src/process.rs
@@ -1710,7 +1710,10 @@ trust_level = "trusted"
         // Only include the issue-linking tag when a valid issue number is provided.
         // When issue_number is 0 (unset/default), omit the tag to avoid "Resolves #0".
         let issue_link_step3 = if issue_number > 0 {
-            format!(", and the linking tag \"Resolves #{}\" to attach the issue to the PR", issue_number)
+            format!(
+                ", and the linking tag \"Resolves #{}\" to attach the issue to the PR",
+                issue_number
+            )
         } else {
             String::new()
         };
@@ -2217,6 +2220,9 @@ mod tests {
         std::fs::write(&worklog_path, "worklog").unwrap();
 
         let prompt = manager.build_forge_pr_prompt(0, &shared);
-        assert!(!prompt.contains("Resolves #"), "Prompt should not contain 'Resolves #' when issue_number is 0");
+        assert!(
+            !prompt.contains("Resolves #"),
+            "Prompt should not contain 'Resolves #' when issue_number is 0"
+        );
     }
 }

--- a/crates/pair-harness/src/process.rs
+++ b/crates/pair-harness/src/process.rs
@@ -1707,6 +1707,19 @@ trust_level = "trusted"
         let worklog = std::fs::read_to_string(&worklog_path)
             .unwrap_or_else(|_| "No WORKLOG.md found".to_string());
 
+        // Only include the issue-linking tag when a valid issue number is provided.
+        // When issue_number is 0 (unset/default), omit the tag to avoid "Resolves #0".
+        let issue_link_step3 = if issue_number > 0 {
+            format!(", and the linking tag \"Resolves #{}\" to attach the issue to the PR", issue_number)
+        } else {
+            String::new()
+        };
+        let issue_link_footer = if issue_number > 0 {
+            format!(" You must also include the linking tag \"Resolves #{}\" in the PR body to link the issue.", issue_number)
+        } else {
+            String::new()
+        };
+
         format!(
             "You are FORGE. SENTINEL has APPROVED and CERTIFIED your implementation. Create the PR.\n\n\
             --- FINAL REVIEW (SENTINEL CERTIFIED) ---\n{}\n\n\
@@ -1727,7 +1740,7 @@ trust_level = "trusted"
                If push is rejected (non-fast-forward), use 'git push --force-with-lease -u origin HEAD'\n\
             3. Create PR using GitHub MCP create_pull_request:\n\
                - title: from CONTRACT summary\n\
-               - body: include SENTINEL's PR description, CERTIFICATION, and the linking tag \"Resolves #{}\" to attach the issue to the PR\n\
+               - body: include SENTINEL's PR description, CERTIFICATION{}\n\
                - head: current branch\n\
                - base: 'main'\n\
                If a PR already exists for this branch, do NOT create a new one — just update STATUS.json with the existing PR info.\n\
@@ -1740,8 +1753,8 @@ trust_level = "trusted"
                  \"sentinel_certified\": true,\n\
                  \"certification\": \"Reviewed and approved by SENTINEL\"\n\
                }}\n\n\
-            Include SENTINEL's certification in PR body. This proves code quality. You must also include the linking tag \"Resolves #{}\" in the PR body to link the issue.",
-            final_review, contract, worklog, shared_path, issue_number, shared_path, issue_number
+            Include SENTINEL's certification in PR body. This proves code quality.{}",
+            final_review, contract, worklog, shared_path, issue_link_step3, shared_path, issue_link_footer
         )
     }
 
@@ -2185,5 +2198,25 @@ mod tests {
 
         let prompt = manager.build_forge_pr_prompt(36, &shared);
         assert!(prompt.contains("Resolves #36"));
+    }
+
+    #[test]
+    fn test_build_forge_pr_prompt_omits_issue_link_when_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let worktree = dir.path().join("worktree");
+        let shared = dir.path().join("shared");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::create_dir_all(&shared).unwrap();
+        let manager = ProcessManager::new("ghp_test", &worktree, &shared);
+
+        let final_review_path = shared.join("final-review.md");
+        let contract_path = shared.join("CONTRACT.md");
+        let worklog_path = shared.join("WORKLOG.md");
+        std::fs::write(&final_review_path, "approved").unwrap();
+        std::fs::write(&contract_path, "contract").unwrap();
+        std::fs::write(&worklog_path, "worklog").unwrap();
+
+        let prompt = manager.build_forge_pr_prompt(0, &shared);
+        assert!(!prompt.contains("Resolves #"), "Prompt should not contain 'Resolves #' when issue_number is 0");
     }
 }

--- a/crates/pair-harness/src/process.rs
+++ b/crates/pair-harness/src/process.rs
@@ -1162,6 +1162,7 @@ trust_level = "trusted"
         &self,
         pair_id: &str,
         ticket_id: &str,
+        issue_number: u64,
         worktree: &Path,
         shared: &Path,
     ) -> Result<Child> {
@@ -1172,7 +1173,7 @@ trust_level = "trusted"
         );
 
         let backend = self.default_backend;
-        let initial_prompt = self.build_forge_pr_prompt(shared);
+        let initial_prompt = self.build_forge_pr_prompt(issue_number, shared);
 
         let mut cmd = self.build_cli_command(backend, worktree, shared);
 
@@ -1694,7 +1695,7 @@ trust_level = "trusted"
     }
 
     /// Build the prompt for PR creation after final SENTINEL approval.
-    fn build_forge_pr_prompt(&self, shared: &Path) -> String {
+    fn build_forge_pr_prompt(&self, issue_number: u64, shared: &Path) -> String {
         let shared_path = shared.display();
         let final_review_path = shared.join("final-review.md");
         let final_review = std::fs::read_to_string(&final_review_path)
@@ -1726,7 +1727,7 @@ trust_level = "trusted"
                If push is rejected (non-fast-forward), use 'git push --force-with-lease -u origin HEAD'\n\
             3. Create PR using GitHub MCP create_pull_request:\n\
                - title: from CONTRACT summary\n\
-               - body: include SENTINEL's PR description and CERTIFICATION\n\
+               - body: include SENTINEL's PR description, CERTIFICATION, and the linking tag \"Resolves #{}\" to attach the issue to the PR\n\
                - head: current branch\n\
                - base: 'main'\n\
                If a PR already exists for this branch, do NOT create a new one — just update STATUS.json with the existing PR info.\n\
@@ -1739,8 +1740,8 @@ trust_level = "trusted"
                  \"sentinel_certified\": true,\n\
                  \"certification\": \"Reviewed and approved by SENTINEL\"\n\
                }}\n\n\
-            Include SENTINEL's certification in PR body. This proves code quality.",
-            final_review, contract, worklog, shared_path, shared_path
+            Include SENTINEL's certification in PR body. This proves code quality. You must also include the linking tag \"Resolves #{}\" in the PR body to link the issue.",
+            final_review, contract, worklog, shared_path, issue_number, shared_path, issue_number
         )
     }
 
@@ -2164,5 +2165,25 @@ mod tests {
         let config = manager.get_backend(CliBackend::Codex);
         let expected_codex_home = worktree.join(".codex-home");
         assert_eq!(config.home_dir(&worktree), expected_codex_home);
+    }
+
+    #[test]
+    fn test_build_forge_pr_prompt_includes_issue_linking() {
+        let dir = tempfile::tempdir().unwrap();
+        let worktree = dir.path().join("worktree");
+        let shared = dir.path().join("shared");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::create_dir_all(&shared).unwrap();
+        let manager = ProcessManager::new("ghp_test", &worktree, &shared);
+
+        let final_review_path = shared.join("final-review.md");
+        let contract_path = shared.join("CONTRACT.md");
+        let worklog_path = shared.join("WORKLOG.md");
+        std::fs::write(&final_review_path, "approved").unwrap();
+        std::fs::write(&contract_path, "contract").unwrap();
+        std::fs::write(&worklog_path, "worklog").unwrap();
+
+        let prompt = manager.build_forge_pr_prompt(36, &shared);
+        assert!(prompt.contains("Resolves #36"));
     }
 }


### PR DESCRIPTION
## Description
This PR addresses issue #36 by ensuring that the `FORGE` agent, when executing under the pair-harness loop in PR-creation mode, receives explicit instructions in its generated prompt to append the issue-linking tag (`Resolves #36`) inside the pull request body.

## Changes
- **`crates/pair-harness/src/pair.rs`**:
  - Added an `issue_number` field to the `ForgeSentinelPair` struct.
  - Initialized `issue_number` from the assigned ticket inside the main event loop.
  - Passed `issue_number` to `spawn_forge_for_pr`.
- **`crates/pair-harness/src/process.rs`**:
  - Modified the signature of `spawn_forge_for_pr` and `build_forge_pr_prompt` to accept the issue number.
  - Updated the prompt template constructed by `build_forge_pr_prompt` to instruct `FORGE` to append `Resolves #<issue_number>` to the PR body.
  - Added a unit test (`test_build_forge_pr_prompt_includes_issue_linking`) to verify the prompt template contains correct formatting.

## Related Issue
Resolves #36