### PR TITLE
feat: auto-release on push to main with stable/edge channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,29 +8,59 @@ Give it a GitHub repo and some issues, and OpenFlows handles everything — writ
 
 ## Quick Start
 
+### Binary Install (recommended)
+
 ```bash
-# Install
+# Stable release
 curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/AgentFlow/main/scripts/install.sh | bash
 
-# Set up your environment (interactive wizard)
-openflows-setup
+# Or edge (pre-release from main)
+curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/AgentFlow/main/scripts/install.sh | bash -s -- --edge
+```
 
-# Run
+Then set up and run:
+
+```bash
+openflows-setup   # interactive wizard — configures repo, API keys, CLI backend
+openflows          # start the autonomous team
+```
+
+### npm Install
+
+```bash
+# Stable release
+npm install -g @the-agenticflow/openflows
+
+# Edge (pre-release)
+npm install -g @the-agenticflow/openflows@next
+```
+
+Then:
+
+```bash
+openflows-setup
 openflows
 ```
 
-That's it. The setup wizard walks you through configuring your GitHub repo, API keys, and CLI backend.
+### Install from Source
 
-<details>
-<summary>Other install options</summary>
+```bash
+git clone https://github.com/The-AgenticFlow/AgentFlow.git
+cd AgentFlow
 
-- **Homebrew (macOS):** `brew tap The-AgenticFlow/openflows && brew install openflows`
-- **Cargo:** `cargo install openflows`
-- **Docker:** See [INSTALL.md](INSTALL.md#option-3-docker)
-- **npm:** `npm install -g @the-agenticflow/openflows`
-- **From source:** See [BUILD.md](BUILD.md)
+# Build and install release binaries
+make install   # installs to ~/.local/bin
 
-</details>
+openflows-setup
+openflows
+```
+
+Or build manually with Cargo:
+
+```bash
+cargo build --release -p openflows
+# Binaries at target/release/{openflows,openflows-setup,openflows-dashboard,openflows-doctor}
+```
 
 ## How It Works
 
@@ -109,18 +139,6 @@ The `openflows-setup` wizard handles configuration interactively. See [.env.exam
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute to OpenFlows |
 | [BUILD.md](BUILD.md) | Building from source |
 | [DEMO.md](DEMO.md) | Quick demo (no API keys needed) |
-
-## For Contributors
-
-```bash
-git clone https://github.com/The-AgenticFlow/AgentFlow.git
-cd AgentFlow
-make install   # build release binaries & install to ~/.local/bin
-openflows-setup
-openflows
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow and [BUILD.md](BUILD.md) for build details.
 
 ## License
 

--- a/binary/src/bin/agentflow.rs
+++ b/binary/src/bin/agentflow.rs
@@ -13,12 +13,31 @@ use pocketflow_core::{Action, Flow, SharedStore};
 use std::sync::Arc;
 use tracing::{info, warn};
 
+fn load_env() -> std::path::PathBuf {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_else(|_| ".".to_string());
+    let openflows_home = std::env::var("OPENFLOWS_HOME")
+        .unwrap_or_else(|_| format!("{}/.openflows", home));
+    let env_paths = vec![
+        std::path::PathBuf::from(format!("{}/.env", openflows_home)),
+        std::env::current_dir().unwrap_or_default().join(".env"),
+    ];
+    for path in &env_paths {
+        if path.exists() {
+            if dotenvy::from_path(path).is_ok() {
+                return path.clone();
+            }
+        }
+    }
+    std::path::PathBuf::new()
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
-    match dotenvy::dotenv() {
-        Ok(path) => eprintln!("Loaded environment from {}", path.display()),
-        Err(dotenvy::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {}
-        Err(err) => return Err(err.into()),
+    let env_path = load_env();
+    if !env_path.as_os_str().is_empty() {
+        eprintln!("Loaded environment from {}", env_path.display());
     }
     // Initialize tracing: default to INFO level, allow RUST_LOG to override
     tracing_subscriber::fmt()
@@ -93,21 +112,31 @@ async fn main() -> Result<()> {
     info!("Starting REAL End-to-End Orchestration (Event-Driven FORGE-SENTINEL Pairs + VESSEL)");
 
     // 1. Validate Environment
-    // Resolve orchestrator_dir: first try relative to the binary itself (npm install),
-    // then fall back to current directory (dev mode).
+    // Resolve orchestrator_dir: search for orchestration/agent/registry.json in
+    // order: (1) next to the binary, (2) the binary's parent dir (npm layout),
+    // (3) AGENTFLOW_HOME, (4) current directory (dev mode).
     let orchestrator_dir = {
-        let exe_dir = std::env::current_exe()
+        let home = std::env::var("AGENTFLOW_HOME")
             .ok()
-            .and_then(|p| p.parent().map(|p| p.to_path_buf()));
-        if let Some(ref dir) = exe_dir {
-            if dir.join("orchestration/agent/registry.json").exists() {
-                dir.clone()
-            } else {
-                std::env::current_dir()?
-            }
-        } else {
-            std::env::current_dir()?
-        }
+            .or_else(|| std::env::var("HOME").ok())
+            .unwrap_or_else(|| "/tmp".to_string());
+        let candidates = vec![
+            std::env::current_exe()
+                .ok()
+                .and_then(|p| p.parent().map(|p| p.to_path_buf())),
+            std::env::current_exe()
+                .ok()
+                .and_then(|p| p.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf())),
+            Some(std::path::PathBuf::from(&home).join(".agentflow")),
+            std::env::current_dir().ok(),
+        ];
+        candidates
+            .into_iter()
+            .flatten()
+            .find(|dir| dir.join("orchestration/agent/registry.json").exists())
+            .ok_or_else(|| anyhow::anyhow!(
+                "Could not find orchestration/agent/registry.json in: binary dir, binary parent, AGENTFLOW_HOME, or current directory"
+            ))?
     };
     let registry_path = orchestrator_dir
         .join("orchestration")

--- a/binary/src/bin/agentflow.rs
+++ b/binary/src/bin/agentflow.rs
@@ -14,13 +14,16 @@ use std::sync::Arc;
 use tracing::{info, warn};
 
 fn load_env() -> anyhow::Result<std::path::PathBuf> {
-    let home = std::env::var("OPENFLOWS_HOME")
-        .or_else(|_| std::env::var("HOME"))
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .map(|h| format!("{}/.openflows", h.trim_end_matches('/')))
+    let openflows_home = std::env::var("OPENFLOWS_HOME")
+        .or_else(|_| {
+            std::env::var("HOME").map(|h| format!("{}/.openflows", h.trim_end_matches('/')))
+        })
+        .or_else(|_| {
+            std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h.trim_end_matches('/')))
+        })
         .unwrap_or_else(|_| ".openflows".to_string());
     let env_paths = vec![
-        std::path::PathBuf::from(format!("{}/.env", home)),
+        std::path::PathBuf::from(format!("{}/.env", openflows_home)),
         std::env::current_dir().unwrap_or_default().join(".env"),
     ];
     for path in &env_paths {

--- a/binary/src/bin/agentflow.rs
+++ b/binary/src/bin/agentflow.rs
@@ -13,29 +13,31 @@ use pocketflow_core::{Action, Flow, SharedStore};
 use std::sync::Arc;
 use tracing::{info, warn};
 
-fn load_env() -> std::path::PathBuf {
-    let home = std::env::var("HOME")
+fn load_env() -> anyhow::Result<std::path::PathBuf> {
+    let home = std::env::var("OPENFLOWS_HOME")
+        .or_else(|_| std::env::var("HOME"))
         .or_else(|_| std::env::var("USERPROFILE"))
-        .unwrap_or_else(|_| ".".to_string());
-    let openflows_home = std::env::var("OPENFLOWS_HOME")
-        .unwrap_or_else(|_| format!("{}/.openflows", home));
+        .map(|h| format!("{}/.openflows", h.trim_end_matches('/')))
+        .unwrap_or_else(|_| ".openflows".to_string());
     let env_paths = vec![
-        std::path::PathBuf::from(format!("{}/.env", openflows_home)),
+        std::path::PathBuf::from(format!("{}/.env", home)),
         std::env::current_dir().unwrap_or_default().join(".env"),
     ];
     for path in &env_paths {
         if path.exists() {
-            if dotenvy::from_path(path).is_ok() {
-                return path.clone();
+            match dotenvy::from_path(path) {
+                Ok(_) => return Ok(path.clone()),
+                Err(dotenvy::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => return Err(err.into()),
             }
         }
     }
-    std::path::PathBuf::new()
+    Ok(std::path::PathBuf::new())
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let env_path = load_env();
+    let env_path = load_env()?;
     if !env_path.as_os_str().is_empty() {
         eprintln!("Loaded environment from {}", env_path.display());
     }
@@ -114,28 +116,30 @@ async fn main() -> Result<()> {
     // 1. Validate Environment
     // Resolve orchestrator_dir: search for orchestration/agent/registry.json in
     // order: (1) next to the binary, (2) the binary's parent dir (npm layout),
-    // (3) AGENTFLOW_HOME, (4) current directory (dev mode).
+    // (3) OPENFLOWS_HOME, (4) current directory (dev mode).
     let orchestrator_dir = {
-        let home = std::env::var("AGENTFLOW_HOME")
-            .ok()
-            .or_else(|| std::env::var("HOME").ok())
-            .unwrap_or_else(|| "/tmp".to_string());
-        let candidates = vec![
+        let mut candidates = vec![
             std::env::current_exe()
                 .ok()
                 .and_then(|p| p.parent().map(|p| p.to_path_buf())),
             std::env::current_exe()
                 .ok()
                 .and_then(|p| p.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf())),
-            Some(std::path::PathBuf::from(&home).join(".agentflow")),
-            std::env::current_dir().ok(),
         ];
+        let openflows_home = std::env::var("OPENFLOWS_HOME")
+            .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
+            .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
+            .ok();
+        if let Some(home) = openflows_home {
+            candidates.push(Some(std::path::PathBuf::from(home)));
+        }
+        candidates.push(std::env::current_dir().ok());
         candidates
             .into_iter()
             .flatten()
             .find(|dir| dir.join("orchestration/agent/registry.json").exists())
             .ok_or_else(|| anyhow::anyhow!(
-                "Could not find orchestration/agent/registry.json in: binary dir, binary parent, AGENTFLOW_HOME, or current directory"
+                "Could not find orchestration/agent/registry.json in: binary dir, binary parent, OPENFLOWS_HOME, or current directory"
             ))?
     };
     let registry_path = orchestrator_dir

--- a/binary/src/bin/demo.rs
+++ b/binary/src/bin/demo.rs
@@ -12,13 +12,16 @@ use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
 fn load_env() -> anyhow::Result<std::path::PathBuf> {
-    let home = std::env::var("OPENFLOWS_HOME")
-        .or_else(|_| std::env::var("HOME"))
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .map(|h| format!("{}/.openflows", h.trim_end_matches('/')))
+    let openflows_home = std::env::var("OPENFLOWS_HOME")
+        .or_else(|_| {
+            std::env::var("HOME").map(|h| format!("{}/.openflows", h.trim_end_matches('/')))
+        })
+        .or_else(|_| {
+            std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h.trim_end_matches('/')))
+        })
         .unwrap_or_else(|_| ".openflows".to_string());
     let env_paths = vec![
-        std::path::PathBuf::from(format!("{}/.env", home)),
+        std::path::PathBuf::from(format!("{}/.env", openflows_home)),
         std::env::current_dir().unwrap_or_default().join(".env"),
     ];
     for path in &env_paths {

--- a/binary/src/bin/demo.rs
+++ b/binary/src/bin/demo.rs
@@ -11,12 +11,31 @@ use std::sync::Arc;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
+fn load_env() -> std::path::PathBuf {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_else(|_| ".".to_string());
+    let openflows_home = std::env::var("OPENFLOWS_HOME")
+        .unwrap_or_else(|_| format!("{}/.openflows", home));
+    let env_paths = vec![
+        std::path::PathBuf::from(format!("{}/.env", openflows_home)),
+        std::env::current_dir().unwrap_or_default().join(".env"),
+    ];
+    for path in &env_paths {
+        if path.exists() {
+            if dotenvy::from_path(path).is_ok() {
+                return path.clone();
+            }
+        }
+    }
+    std::path::PathBuf::new()
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
-    match dotenvy::dotenv() {
-        Ok(path) => eprintln!("Loaded environment from {}", path.display()),
-        Err(dotenvy::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {}
-        Err(err) => return Err(err.into()),
+    let env_path = load_env();
+    if !env_path.as_os_str().is_empty() {
+        eprintln!("Loaded environment from {}", env_path.display());
     }
     // 1. Setup logging
     let subscriber = FmtSubscriber::builder()

--- a/binary/src/bin/demo.rs
+++ b/binary/src/bin/demo.rs
@@ -11,29 +11,31 @@ use std::sync::Arc;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
-fn load_env() -> std::path::PathBuf {
-    let home = std::env::var("HOME")
+fn load_env() -> anyhow::Result<std::path::PathBuf> {
+    let home = std::env::var("OPENFLOWS_HOME")
+        .or_else(|_| std::env::var("HOME"))
         .or_else(|_| std::env::var("USERPROFILE"))
-        .unwrap_or_else(|_| ".".to_string());
-    let openflows_home = std::env::var("OPENFLOWS_HOME")
-        .unwrap_or_else(|_| format!("{}/.openflows", home));
+        .map(|h| format!("{}/.openflows", h.trim_end_matches('/')))
+        .unwrap_or_else(|_| ".openflows".to_string());
     let env_paths = vec![
-        std::path::PathBuf::from(format!("{}/.env", openflows_home)),
+        std::path::PathBuf::from(format!("{}/.env", home)),
         std::env::current_dir().unwrap_or_default().join(".env"),
     ];
     for path in &env_paths {
         if path.exists() {
-            if dotenvy::from_path(path).is_ok() {
-                return path.clone();
+            match dotenvy::from_path(path) {
+                Ok(_) => return Ok(path.clone()),
+                Err(dotenvy::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => return Err(err.into()),
             }
         }
     }
-    std::path::PathBuf::new()
+    Ok(std::path::PathBuf::new())
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let env_path = load_env();
+    let env_path = load_env()?;
     if !env_path.as_os_str().is_empty() {
         eprintln!("Loaded environment from {}", env_path.display());
     }

--- a/binary/src/main.rs
+++ b/binary/src/main.rs
@@ -18,16 +18,12 @@ use crate::state::{
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let env_home = std::env::var("OPENFLOWS_HOME").unwrap_or_else(|_| {
-        format!(
-            "{}/.openflows",
-            std::env::var("HOME")
-                .or_else(|_| std::env::var("USERPROFILE"))
-                .unwrap_or_else(|_| ".".to_string())
-        )
-    });
+    let openflows_home = std::env::var("OPENFLOWS_HOME")
+        .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
+        .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
+        .unwrap_or_else(|_| ".openflows".to_string());
     let env_paths = vec![
-        std::path::PathBuf::from(format!("{}/.env", env_home)),
+        std::path::PathBuf::from(format!("{}/.env", openflows_home)),
         std::env::current_dir().unwrap_or_default().join(".env"),
     ];
     for path in &env_paths {
@@ -126,28 +122,30 @@ async fn main() -> Result<()> {
     // 4. Build Flow - use orchestration/agent directory for personas
     // Resolve orchestrator_dir: search for orchestration/agent/registry.json in
     // order: (1) next to the binary, (2) the binary's parent dir (npm layout),
-    // (3) AGENTFLOW_HOME, (4) current directory (dev mode).
+    // (3) OPENFLOWS_HOME, (4) current directory (dev mode).
     let orchestrator_dir = {
-        let home = std::env::var("AGENTFLOW_HOME")
-            .ok()
-            .or_else(|| std::env::var("HOME").ok())
-            .unwrap_or_else(|| "/tmp".to_string());
-        let candidates = vec![
+        let mut candidates = vec![
             std::env::current_exe()
                 .ok()
                 .and_then(|p| p.parent().map(|p| p.to_path_buf())),
             std::env::current_exe()
                 .ok()
                 .and_then(|p| p.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf())),
-            Some(std::path::PathBuf::from(&home).join(".agentflow")),
-            std::env::current_dir().ok(),
         ];
+        let openflows_home = std::env::var("OPENFLOWS_HOME")
+            .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
+            .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
+            .ok();
+        if let Some(home) = openflows_home {
+            candidates.push(Some(std::path::PathBuf::from(home)));
+        }
+        candidates.push(std::env::current_dir().ok());
         candidates
             .into_iter()
             .flatten()
             .find(|dir| dir.join("orchestration/agent/registry.json").exists())
             .ok_or_else(|| anyhow::anyhow!(
-                "Could not find orchestration/agent/registry.json in: binary dir, binary parent, AGENTFLOW_HOME, or current directory"
+                "Could not find orchestration/agent/registry.json in: binary dir, binary parent, OPENFLOWS_HOME, or current directory"
             ))?
     };
     let registry_path = orchestrator_dir.join("orchestration/agent/registry.json");

--- a/binary/src/main.rs
+++ b/binary/src/main.rs
@@ -18,10 +18,29 @@ use crate::state::{
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    match dotenvy::dotenv() {
-        Ok(path) => eprintln!("Loaded environment from {}", path.display()),
-        Err(dotenvy::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {}
-        Err(err) => return Err(err.into()),
+    let env_home = std::env::var("OPENFLOWS_HOME").unwrap_or_else(|_| {
+        format!(
+            "{}/.openflows",
+            std::env::var("HOME")
+                .or_else(|_| std::env::var("USERPROFILE"))
+                .unwrap_or_else(|_| ".".to_string())
+        )
+    });
+    let env_paths = vec![
+        std::path::PathBuf::from(format!("{}/.env", env_home)),
+        std::env::current_dir().unwrap_or_default().join(".env"),
+    ];
+    for path in &env_paths {
+        if path.exists() {
+            match dotenvy::from_path(path) {
+                Ok(_) => {
+                    eprintln!("Loaded environment from {}", path.display());
+                    break;
+                }
+                Err(dotenvy::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => return Err(err.into()),
+            }
+        }
     }
     // Initialize tracing: default to INFO level, allow RUST_LOG to override
     tracing_subscriber::fmt()
@@ -105,21 +124,31 @@ async fn main() -> Result<()> {
     store.set(KEY_PENDING_PRS, serde_json::json!([])).await;
 
     // 4. Build Flow - use orchestration/agent directory for personas
-    // Resolve orchestrator_dir: first try relative to the binary itself (npm install),
-    // then fall back to current directory (dev mode).
+    // Resolve orchestrator_dir: search for orchestration/agent/registry.json in
+    // order: (1) next to the binary, (2) the binary's parent dir (npm layout),
+    // (3) AGENTFLOW_HOME, (4) current directory (dev mode).
     let orchestrator_dir = {
-        let exe_dir = std::env::current_exe()
+        let home = std::env::var("AGENTFLOW_HOME")
             .ok()
-            .and_then(|p| p.parent().map(|p| p.to_path_buf()));
-        if let Some(ref dir) = exe_dir {
-            if dir.join("orchestration/agent/registry.json").exists() {
-                dir.clone()
-            } else {
-                std::env::current_dir()?
-            }
-        } else {
-            std::env::current_dir()?
-        }
+            .or_else(|| std::env::var("HOME").ok())
+            .unwrap_or_else(|| "/tmp".to_string());
+        let candidates = vec![
+            std::env::current_exe()
+                .ok()
+                .and_then(|p| p.parent().map(|p| p.to_path_buf())),
+            std::env::current_exe()
+                .ok()
+                .and_then(|p| p.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf())),
+            Some(std::path::PathBuf::from(&home).join(".agentflow")),
+            std::env::current_dir().ok(),
+        ];
+        candidates
+            .into_iter()
+            .flatten()
+            .find(|dir| dir.join("orchestration/agent/registry.json").exists())
+            .ok_or_else(|| anyhow::anyhow!(
+                "Could not find orchestration/agent/registry.json in: binary dir, binary parent, AGENTFLOW_HOME, or current directory"
+            ))?
     };
     let registry_path = orchestrator_dir.join("orchestration/agent/registry.json");
     let registry = config::Registry::load(&registry_path)?;

--- a/crates/agentflow-tui/src/doctor/mod.rs
+++ b/crates/agentflow-tui/src/doctor/mod.rs
@@ -48,7 +48,16 @@ async fn run_doctor_inner(mut terminal: Terminal<CrosstermBackend<io::Stdout>>) 
 
     checks.push(("── Configuration ──".to_string(), CheckState::Pending));
 
-    if std::path::Path::new(".env").exists() {
+    let home = std::env::var("OPENFLOWS_HOME").unwrap_or_else(|_| {
+        format!(
+            "{}/.openflows",
+            std::env::var("HOME")
+                .or_else(|_| std::env::var("USERPROFILE"))
+                .unwrap_or_else(|_| ".".to_string())
+        )
+    });
+    let env_path = std::path::Path::new(&home).join(".env");
+    if env_path.exists() || std::path::Path::new(".env").exists() {
         checks.push((".env file exists".to_string(), CheckState::Pass));
     } else {
         checks.push((".env file missing".to_string(), CheckState::Fail));

--- a/crates/agentflow-tui/src/setup/step_done.rs
+++ b/crates/agentflow-tui/src/setup/step_done.rs
@@ -5,7 +5,6 @@ use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 use ratatui::Terminal;
 use std::io;
-use std::path::Path;
 
 use crate::setup::write_env_file;
 use crate::setup::write_registry_file;
@@ -41,6 +40,7 @@ impl DoneStep {
         write_env_file(config, &openflows_home)?;
         let current_dir = std::env::current_dir()?;
         write_registry_file(config, &current_dir)?;
+        write_registry_file(config, &openflows_home)?;
 
         let env_path = openflows_home.join(".env");
         let registry_path = current_dir
@@ -51,7 +51,10 @@ impl DoneStep {
         let mut checks = Vec::new();
 
         if env_path.exists() {
-            checks.push((format!(".env written to {}", env_path.display()), CheckState::Pass));
+            checks.push((
+                format!(".env written to {}", env_path.display()),
+                CheckState::Pass,
+            ));
         } else {
             checks.push((".env file write failed".to_string(), CheckState::Fail));
         }

--- a/crates/agentflow-tui/src/setup/step_done.rs
+++ b/crates/agentflow-tui/src/setup/step_done.rs
@@ -27,10 +27,22 @@ impl DoneStep {
         theme: &Theme,
         config: &SetupConfig,
     ) -> Result<()> {
+        let home = std::env::var("OPENFLOWS_HOME").unwrap_or_else(|_| {
+            format!(
+                "{}/.openflows",
+                std::env::var("HOME")
+                    .or_else(|_| std::env::var("USERPROFILE"))
+                    .unwrap_or_else(|_| ".".to_string())
+            )
+        });
+        let openflows_home = std::path::PathBuf::from(&home);
+        std::fs::create_dir_all(&openflows_home)?;
+
+        write_env_file(config, &openflows_home)?;
         let current_dir = std::env::current_dir()?;
-        write_env_file(config, &current_dir)?;
         write_registry_file(config, &current_dir)?;
 
+        let env_path = openflows_home.join(".env");
         let registry_path = current_dir
             .join("orchestration")
             .join("agent")
@@ -38,8 +50,8 @@ impl DoneStep {
 
         let mut checks = Vec::new();
 
-        if Path::new(".env").exists() {
-            checks.push((".env file written".to_string(), CheckState::Pass));
+        if env_path.exists() {
+            checks.push((format!(".env written to {}", env_path.display()), CheckState::Pass));
         } else {
             checks.push((".env file write failed".to_string(), CheckState::Fail));
         }

--- a/crates/agentflow-tui/src/setup/step_existing.rs
+++ b/crates/agentflow-tui/src/setup/step_existing.rs
@@ -42,7 +42,21 @@ impl ExistingConfigStep {
     }
 
     pub fn detect_existing_config(project_dir: &Path) -> Option<SetupConfig> {
-        let env_path = project_dir.join(".env");
+        let home = std::env::var("OPENFLOWS_HOME").unwrap_or_else(|_| {
+            format!(
+                "{}/.openflows",
+                std::env::var("HOME")
+                    .or_else(|_| std::env::var("USERPROFILE"))
+                    .unwrap_or_else(|_| ".".to_string())
+            )
+        });
+        let openflows_env = std::path::Path::new(&home).join(".env");
+        let local_env = project_dir.join(".env");
+        let env_path = if openflows_env.exists() {
+            openflows_env
+        } else {
+            local_env
+        };
         if !env_path.exists() {
             return None;
         }

--- a/crates/agentflow-tui/src/setup/step_existing.rs
+++ b/crates/agentflow-tui/src/setup/step_existing.rs
@@ -42,15 +42,18 @@ impl ExistingConfigStep {
     }
 
     pub fn detect_existing_config(project_dir: &Path) -> Option<SetupConfig> {
-        let home = std::env::var("OPENFLOWS_HOME").unwrap_or_else(|_| {
-            format!(
-                "{}/.openflows",
-                std::env::var("HOME")
-                    .or_else(|_| std::env::var("USERPROFILE"))
-                    .unwrap_or_else(|_| ".".to_string())
-            )
-        });
-        let openflows_env = std::path::Path::new(&home).join(".env");
+        let openflows_env = std::env::var("OPENFLOWS_HOME")
+            .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
+            .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
+            .ok()
+            .map(std::path::PathBuf::from)
+            .map(|p| p.join(".env"))
+            .unwrap_or_else(|| {
+                std::path::PathBuf::from(format!(
+                    "{}/.openflows/.env",
+                    std::env::var("HOME").unwrap_or_else(|_| ".".to_string())
+                ))
+            });
         let local_env = project_dir.join(".env");
         let env_path = if openflows_env.exists() {
             openflows_env

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "@the-agenticflow/openflows",
+  "name": "openflows",
   "version": "0.1.2",
   "description": "Autonomous AI development team — turns GitHub issues into working PRs",
-  "main": "index.js",
   "bin": {
     "openflows": "./bin/openflows.js",
     "openflows-setup": "./bin/openflows-setup.js",
@@ -39,12 +38,5 @@
   "cpu": [
     "x64",
     "arm64"
-  ],
-  "optionalDependencies": {
-    "@openflows/linux-x64-gnu": "0.1.0",
-    "@openflows/linux-x64-musl": "0.1.0",
-    "@openflows/linux-arm64-gnu": "0.1.0",
-    "@openflows/darwin-x64": "0.1.0",
-    "@openflows/darwin-arm64": "0.1.0"
-  }
+  ]
 }

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openflows",
+  "name": "@the-agenticflow/openflows",
   "version": "0.1.2",
   "description": "Autonomous AI development team — turns GitHub issues into working PRs",
   "bin": {

--- a/packaging/npm/scripts/install.js
+++ b/packaging/npm/scripts/install.js
@@ -11,6 +11,7 @@ const { execSync } = require('child_process');
 
 const REPO = 'The-AgenticFlow/AgentFlow';
 const BIN_DIR = path.join(__dirname, '..', 'bin');
+const PKG_DIR = path.join(__dirname, '..');
 
 function detectPlatform() {
     const platform = os.platform();
@@ -177,6 +178,17 @@ async function main() {
             fs.renameSync(src, dst);
             fs.chmodSync(dst, 0o755);
         }
+    }
+
+    // Move orchestration config to package root so the binary can find it
+    const orchestrationSrc = path.join(BIN_DIR, 'orchestration');
+    const orchestrationDst = path.join(PKG_DIR, 'orchestration');
+    if (fs.existsSync(orchestrationSrc)) {
+        if (fs.existsSync(orchestrationDst)) {
+            fs.rmSync(orchestrationDst, { recursive: true });
+        }
+        fs.renameSync(orchestrationSrc, orchestrationDst);
+        console.log('[openflows] Installed orchestration config');
     }
 
     if (fs.existsSync(tmpFile)) {

--- a/packaging/npm/scripts/install.js
+++ b/packaging/npm/scripts/install.js
@@ -123,7 +123,7 @@ async function fetchLatestTag(includePrerelease = false) {
 async function main() {
     const platform = detectPlatform();
     const channel = process.env.AGENTFLOW_CHANNEL || (process.env.npm_package_version?.includes('-dev.') ? 'edge' : 'stable');
-    console.log(`[@the-agenticflow/openflows] Downloading binary for ${platform} (${channel})...`);
+    console.log(`[openflows] Downloading binary for ${platform} (${channel})...`);
 
     // Ensure bin directory exists
     if (!fs.existsSync(BIN_DIR)) {
@@ -136,7 +136,7 @@ async function main() {
         if (channel === 'edge') {
             tag = await fetchLatestTag(true);
             if (!tag) {
-                console.warn('[@the-agenticflow/openflows] No edge release found, falling back to latest stable');
+                console.warn('[openflows] No edge release found, falling back to latest stable');
                 tag = await fetchLatestTag(false);
             }
         } else {
@@ -159,7 +159,7 @@ async function main() {
             const muslArchiveName = `openflows-${tag}-x86_64-unknown-linux-musl.tar.gz`;
             const muslDownloadUrl = `https://github.com/${REPO}/releases/download/${tag}/${muslArchiveName}`;
             const muslTmpFile = path.join(os.tmpdir(), muslArchiveName);
-            console.log(`[@the-agenticflow/openflows] Trying musl fallback...`);
+            console.log(`[openflows] Trying musl fallback...`);
             await download(muslDownloadUrl, muslTmpFile);
             await extractTarGz(muslTmpFile, BIN_DIR);
             fs.unlinkSync(muslTmpFile);

--- a/packaging/npm/scripts/install.js
+++ b/packaging/npm/scripts/install.js
@@ -123,7 +123,7 @@ async function fetchLatestTag(includePrerelease = false) {
 async function main() {
     const platform = detectPlatform();
     const channel = process.env.AGENTFLOW_CHANNEL || (process.env.npm_package_version?.includes('-dev.') ? 'edge' : 'stable');
-    console.log(`[openflows] Downloading binary for ${platform} (${channel})...`);
+    console.log(`[@the-agenticflow/openflows] Downloading binary for ${platform} (${channel})...`);
 
     // Ensure bin directory exists
     if (!fs.existsSync(BIN_DIR)) {
@@ -136,7 +136,7 @@ async function main() {
         if (channel === 'edge') {
             tag = await fetchLatestTag(true);
             if (!tag) {
-                console.warn('[openflows] No edge release found, falling back to latest stable');
+                console.warn('[@the-agenticflow/openflows] No edge release found, falling back to latest stable');
                 tag = await fetchLatestTag(false);
             }
         } else {
@@ -159,7 +159,7 @@ async function main() {
             const muslArchiveName = `openflows-${tag}-x86_64-unknown-linux-musl.tar.gz`;
             const muslDownloadUrl = `https://github.com/${REPO}/releases/download/${tag}/${muslArchiveName}`;
             const muslTmpFile = path.join(os.tmpdir(), muslArchiveName);
-            console.log(`[openflows] Trying musl fallback...`);
+            console.log(`[@the-agenticflow/openflows] Trying musl fallback...`);
             await download(muslDownloadUrl, muslTmpFile);
             await extractTarGz(muslTmpFile, BIN_DIR);
             fs.unlinkSync(muslTmpFile);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -190,6 +190,12 @@ download_binary() {
             chmod +x "${INSTALL_DIR}/${bin}"
         fi
     done
+
+    if [ -d "${extract_dir}/orchestration" ]; then
+        cp -r "${extract_dir}/orchestration" "${INSTALL_DIR}/"
+        success "Installed orchestration config to ${INSTALL_DIR}/orchestration/"
+    fi
+
     rm -rf "${extract_dir}"
 
     success "Downloaded and extracted to ${INSTALL_DIR}/"


### PR DESCRIPTION
## Summary

Adds automatic edge releases on every push to `main` (with dev version strings like `vX.Y.Z-dev.N.SHA`) alongside stable releases on tag pushes, plus channel-aware install scripts, npm publishing with `next`/`latest` dist-tags, and Homebrew formula auto-updates on stable releases. Also removes the duplicate `release-binaries` job from `ci.yml`.

## Changes

- **Release workflow**: New `resolve-version` job computes version strings for tag pushes, main pushes, and workflow dispatch. Edge versions use format `vX.Y.Z-dev.N.SHA` (dot-separated, no `+`). Docker images use `edge` tag for prereleases and `latest` for stable. Homebrew formula auto-updates on stable releases with `[skip ci]` commit message and `paths-ignore` to prevent re-triggering. Concurrency group added to prevent race conditions.
- **Install script** (`scripts/install.sh`): Adds `--edge`/`--stable` flags and `AGENTFLOW_CHANNEL` env var. Edge channel queries GitHub prereleases. Uses `jq` for reliable JSON parsing in curl fallback.
- **npm package** (`packaging/npm/`): Unscoped package name (`openflows`) to fix E404 on publish. Post-install script downloads platform-specific binaries. Removed non-existent `optionalDependencies`.
- **CI** (`.github/workflows/ci.yml`): Removed duplicate `release-binaries` job.
- **PACKAGING.md**: Updated documentation for new channel system.

## Fixes from review feedback

- Stable tag lookup filters out `-dev.` tags to prevent garbled version strings
- Docker `latest` tag only used for stable releases; `edge` tag for prereleases
- `resolve_edge_tag` curl fallback uses `jq` instead of fragile grep-based JSON parsing
- Homebrew push uses `[skip ci]` + `paths-ignore` to prevent workflow re-trigger
- Dev version format uses `.` separator instead of `+` for SHA
- RC/beta/alpha tags correctly detected as prereleases
- Concurrency group prevents overlapping release runs

----
## Summary by Gitar

- **Configuration management:**
  - Updated `agentflow.rs`, `main.rs`, and `demo.rs` to load `.env` from `~/.openflows` as a priority location.
  - Enhanced configuration discovery logic to search binary, parent, `AGENTFLOW_HOME`, and current directories for `orchestration/agent/registry.json`.
- **Orchestration packaging:**
  - Modified `install.js` and `install.sh` to relocate `orchestration` config to the installation root, ensuring the binary can locate it.
- **TUI & Doctor updates:**
  - Updated `agentflow-tui` setup and doctor modules to support the new global `~/.openflows` configuration path.
- **Documentation:**
  - Overhauled `README.md` with updated Quick Start guides for binary, npm, and source-based installations.


<sub>This will update automatically on new commits.</sub>