### PR TITLE
feat: auto-release on push to main with stable/edge channels (v1.0.16)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,7 +253,7 @@ jobs:
           echo "## Installation" >> CHANGELOG.md
           echo "" >> CHANGELOG.md
           echo '```bash' >> CHANGELOG.md
-          echo 'curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/AgentFlow/main/scripts/install.sh | bash' >> CHANGELOG.md
+          echo 'curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/openflows/main/scripts/install.sh | bash' >> CHANGELOG.md
           echo '```' >> CHANGELOG.md
 
           cat CHANGELOG.md

--- a/BUILD.md
+++ b/BUILD.md
@@ -67,7 +67,7 @@ See [docs/setup-claude-cli.md](docs/setup-claude-cli.md) and [docs/cli-backend-c
 ## Clone the Repository
 
 ```bash
-git clone https://github.com/The-AgenticFlow/AgentFlow.git
+git clone https://github.com/The-AgenticFlow/openflows.git
 cd AgentFlow
 ```
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -68,7 +68,7 @@ See [docs/setup-claude-cli.md](docs/setup-claude-cli.md) and [docs/cli-backend-c
 
 ```bash
 git clone https://github.com/The-AgenticFlow/openflows.git
-cd AgentFlow
+cd openflows
 ```
 
 ## Build Commands

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openflows"
-version = "0.1.0"
+version = "1.0.16"
 dependencies = [
  "agent-forge",
  "agent-lore",

--- a/DEMO.md
+++ b/DEMO.md
@@ -19,7 +19,7 @@ This guide walks you through running a complete autonomous development cycle, fr
 ### 1. Clone and Configure
 
 ```bash
-git clone https://github.com/The-AgenticFlow/AgentFlow.git
+git clone https://github.com/The-AgenticFlow/openflows.git
 cd AgentFlow
 
 # Copy environment template

--- a/DEMO.md
+++ b/DEMO.md
@@ -20,7 +20,7 @@ This guide walks you through running a complete autonomous development cycle, fr
 
 ```bash
 git clone https://github.com/The-AgenticFlow/openflows.git
-cd AgentFlow
+cd openflows
 
 # Copy environment template
 cp .env.example .env
@@ -303,7 +303,7 @@ GITHUB_REPOSITORY=your-username/my-calculator
 ### 4. Run Orchestration
 
 ```bash
-cd AgentFlow
+cd openflows
 cargo run --bin openflows
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -98,7 +98,7 @@ Use this path if you want to contribute code, debug issues, or run the latest un
 ```bash
 # Clone the repository
 git clone https://github.com/The-AgenticFlow/openflows.git
-cd AgentFlow
+cd openflows
 
 # Verify Rust is installed (need 1.70+)
 rustc --version

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ Choose one of these if you only want to run OpenFlows and do not plan to modify 
 ### Option 1: One-Line Install (Recommended)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/AgentFlow/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/openflows/main/scripts/install.sh | bash
 ```
 
 This installs all binaries to `~/.local/bin` and offers to run the setup wizard.
@@ -97,7 +97,7 @@ Use this path if you want to contribute code, debug issues, or run the latest un
 
 ```bash
 # Clone the repository
-git clone https://github.com/The-AgenticFlow/AgentFlow.git
+git clone https://github.com/The-AgenticFlow/openflows.git
 cd AgentFlow
 
 # Verify Rust is installed (need 1.70+)

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,13 @@ install: release
 		chmod +x "$$INSTALL_DIR/$$bin"; \
 		echo "  Installed $$INSTALL_DIR/$$bin"; \
 	done
+	@if [ -d "orchestration" ]; then \
+		INSTALL_DIR="$${AGENTFLOW_INSTALL_DIR:-$$HOME/.local/bin}"; \
+		cp -r orchestration "$$INSTALL_DIR/"; \
+		echo "  Installed orchestration config to $$INSTALL_DIR/orchestration/"; \
+	fi
 	@echo ""
-	@echo "Make sure $$INSTALL_DIR is in your PATH."
+	@echo "Make sure $${AGENTFLOW_INSTALL_DIR:-$$HOME/.local/bin} is in your PATH."
 
 clean:
 	cargo clean

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -43,13 +43,13 @@ Edge builds let you test the latest changes without waiting for a stable release
 
 ```bash
 # Stable release (default)
-curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/AgentFlow/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/openflows/main/scripts/install.sh | bash
 
 # Edge (pre-release from main)
-curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/AgentFlow/main/scripts/install.sh | bash -s -- --edge
+curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/openflows/main/scripts/install.sh | bash -s -- --edge
 
 # Custom install directory
-curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/AgentFlow/main/scripts/install.sh | bash -s -- --dir /usr/local/bin
+curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/openflows/main/scripts/install.sh | bash -s -- --dir /usr/local/bin
 ```
 
 **What it does:**
@@ -123,7 +123,7 @@ All crates are published to crates.io. The `openflows` package includes all bina
 ### 6. Build from Source
 
 ```bash
-git clone https://github.com/The-AgenticFlow/AgentFlow.git
+git clone https://github.com/The-AgenticFlow/openflows.git
 cd AgentFlow
 make release    # Builds all binaries in release mode
 make install    # Copies to ~/.local/bin

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -124,7 +124,7 @@ All crates are published to crates.io. The `openflows` package includes all bina
 
 ```bash
 git clone https://github.com/The-AgenticFlow/openflows.git
-cd AgentFlow
+cd openflows
 make release    # Builds all binaries in release mode
 make install    # Copies to ~/.local/bin
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ openflows
 
 ```bash
 git clone https://github.com/The-AgenticFlow/openflows.git
-cd AgentFlow
+cd openflows
 
 # Build and install release binaries
 make install   # installs to ~/.local/bin

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Or build manually with Cargo:
 ```bash
 cargo build --release -p openflows
 # Binaries at target/release/{openflows,openflows-setup,openflows-dashboard,openflows-doctor}
+# You also need the orchestration/ directory — copy it to ~/.local/bin/ or set OPENFLOWS_HOME
+cp -r orchestration ~/.local/bin/
 ```
 
 ## How It Works

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Give it a GitHub repo and some issues, and OpenFlows handles everything — writ
 
 ```bash
 # Stable release
-curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/AgentFlow/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/openflows/main/scripts/install.sh | bash
 
 # Or edge (pre-release from main)
-curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/AgentFlow/main/scripts/install.sh | bash -s -- --edge
+curl -fsSL https://raw.githubusercontent.com/The-AgenticFlow/openflows/main/scripts/install.sh | bash -s -- --edge
 ```
 
 Then set up and run:
@@ -45,7 +45,7 @@ openflows
 ### Install from Source
 
 ```bash
-git clone https://github.com/The-AgenticFlow/AgentFlow.git
+git clone https://github.com/The-AgenticFlow/openflows.git
 cd AgentFlow
 
 # Build and install release binaries

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -60,7 +60,7 @@ For the GitHub token, ensure these scopes:
 
 ```bash
 git clone https://github.com/The-AgenticFlow/openflows.git
-cd AgentFlow
+cd openflows
 ```
 
 ### 2. Create `.env` File

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -59,7 +59,7 @@ For the GitHub token, ensure these scopes:
 ### 1. Clone OpenFlows
 
 ```bash
-git clone https://github.com/The-AgenticFlow/AgentFlow.git
+git clone https://github.com/The-AgenticFlow/openflows.git
 cd AgentFlow
 ```
 
@@ -804,7 +804,7 @@ OpenFlows/                                    # Orchestrator project
 - [DEMO.md](DEMO.md) - Quick demo guide
 - [CONTRIBUTING.md](CONTRIBUTING.md) - Development guidelines  
 - [docs/forge-sentinel-arch.md](docs/forge-sentinel-arch.md) - Architecture deep dive
-- [GitHub Discussions](https://github.com/The-AgenticFlow/AgentFlow/discussions) - Ask questions
+- [GitHub Discussions](https://github.com/The-AgenticFlow/openflows/discussions) - Ask questions
 
 ---
 

--- a/binary/Cargo.toml
+++ b/binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "openflows"
-version = "0.1.0"
+version = "1.0.16"
 edition = "2021"
 license = "MIT"
 

--- a/docs/agentflow-pair-harness.md
+++ b/docs/agentflow-pair-harness.md
@@ -209,7 +209,7 @@ Total: 75 tests, all passing. Zero backend-specific conditional logic in tests. 
 
 ## Try It
 
-The full implementation is at [github.com/The-AgenticFlow/AgentFlow](https://github.com/The-AgenticFlow/AgentFlow). The pair harness is in `crates/pair-harness/`, with the `BackendConfig` abstraction in `src/process.rs` and the provisioning pipeline in `src/provision.rs`.
+The full implementation is at [github.com/The-AgenticFlow/openflows](https://github.com/The-AgenticFlow/openflows). The pair harness is in `crates/pair-harness/`, with the `BackendConfig` abstraction in `src/process.rs` and the provisioning pipeline in `src/provision.rs`.
 
 Claude:
 ```

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-agenticflow/openflows",
-  "version": "0.1.2",
+  "version": "1.0.16",
   "description": "Autonomous AI development team — turns GitHub issues into working PRs",
   "bin": {
     "openflows": "./bin/openflows.js",

--- a/packaging/npm/scripts/install.js
+++ b/packaging/npm/scripts/install.js
@@ -9,7 +9,7 @@ const path = require('path');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const REPO = 'The-AgenticFlow/AgentFlow';
+const REPO = 'The-AgenticFlow/openflows';
 const BIN_DIR = path.join(__dirname, '..', 'bin');
 const PKG_DIR = path.join(__dirname, '..');
 

--- a/scripts/demo_recording_guide.md
+++ b/scripts/demo_recording_guide.md
@@ -161,7 +161,7 @@ Open `http://localhost:8000` in browser and demo the calculator.
 **Narration**:
 > "That's AgentFlow - an autonomous development team that can handle your GitHub issues from start to finish. Check out the repository to learn more and try it yourself."
 
-**Show**: GitHub repo URL: `github.com/The-AgenticFlow/AgentFlow`
+**Show**: GitHub repo URL: `github.com/The-AgenticFlow/openflows`
 
 ## Recording Tips
 
@@ -267,7 +267,7 @@ Show:
 ## Need Help?
 
 If you need help creating a demo video:
-- Open a discussion: https://github.com/The-AgenticFlow/AgentFlow/discussions
+- Open a discussion: https://github.com/The-AgenticFlow/openflows/discussions
 - We may feature community demos in the README!
 
 ---

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-REPO="The-AgenticFlow/AgentFlow"
+REPO="The-AgenticFlow/openflows"
 INSTALL_DIR="${AGENTFLOW_INSTALL_DIR:-$HOME/.local/bin}"
 BINARIES=("openflows" "openflows-setup" "openflows-dashboard" "openflows-doctor")
 CHANNEL="stable"


### PR DESCRIPTION
## Summary

Adds automatic edge releases on every push to `main` alongside stable releases on tag pushes, plus channel-aware install scripts, npm publishing with `next`/`latest` dist-tags, Homebrew formula auto-updates, and several runtime fixes. Bumps version to **1.0.16**.

## Changes

### Release workflow (`.github/workflows/release.yml`)
- New `resolve-version` job computes version strings for tag pushes, main pushes, and workflow dispatch
- Edge versions use format `vX.Y.Z-dev.N.SHA` (dot-separated, no `+`)
- Docker images use `edge` tag for prereleases, `latest` for stable
- Homebrew formula auto-updates on stable releases with `[skip ci]` + `paths-ignore`
- Concurrency group prevents overlapping release runs
- RC/beta/alpha tags correctly detected as prereleases
- Stable tag lookup filters out `-dev.` tags

### Install script (`scripts/install.sh`)
- `--edge`/`--stable` flags and `AGENTFLOW_CHANNEL` env var
- `resolve_edge_tag` uses `jq` for reliable curl fallback JSON parsing
- Copies `orchestration/` directory alongside binaries
- Repo URL updated from `AgentFlow` to `openflows`

### npm package (`packaging/npm/`)
- Post-install script downloads platform-specific binaries
- `orchestration/` dir moved to package root after extraction
- Repo URL updated

### Binary runtime
- `.env` loading: checks `$OPENFLOWS_HOME/.env` then `./env` — `OPENFLOWS_HOME` used directly (no double-appending `/.openflows`)
- `orchestration/` resolution: searches binary dir → binary parent (npm layout) → `OPENFLOWS_HOME`/`.openflows` → current directory
- Parse errors in `.env` are now propagated instead of silently swallowed
- No `/tmp` fallback for home directory

### Setup wizard & doctor
- Writes `.env` to `~/.openflows/` instead of current directory
- Writes `registry.json` to both `current_dir/orchestration` and `~/.openflows/orchestration`
- Detects existing config from both `~/.openflows/.env` and local `.env`

### Makefile
- `make install` now copies `orchestration/` alongside binaries

### Documentation
- README Quick Start expanded with binary, npm, and source install sections
- All repo URLs updated from `The-AgenticFlow/AgentFlow` to `The-AgenticFlow/openflows`
- Cargo build docs note that `orchestration/` must be manually copied

### Version
- Cargo.toml: `0.1.0` → `1.0.16`
- npm package.json: `0.1.2` → `1.0.16`

## Fixes from review feedback
- Stable tag lookup filters out `-dev.` tags
- Docker `latest` tag only for stable; `edge` for prereleases
- `resolve_edge_tag` curl fallback uses `jq`
- Homebrew push uses `[skip ci]` + `paths-ignore`
- Dev version format uses `.` separator instead of `+` for SHA
- RC/beta/alpha tags detected as prereleases
- Concurrency group prevents overlapping runs
- `OPENFLOWS_HOME` used consistently (not `AGENTFLOW_HOME`)
- `.env` parse errors propagated, not silently swallowed
- No `/tmp` fallback for home directory
- `load_env()` treats `OPENFLOWS_HOME` as direct path (no double-appending `/.openflows`)