### PR TITLE
feat: embed all orchestration files at compile time with self-healing…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,15 +100,12 @@ forge/STATUS.json
 # Worker runtime data (top-level forge/ directory only)
 /forge/
 
-# Orchestration runtime data (but keep plugin and agent config)
+# Orchestration runtime data (keep plugin and agent config tracked)
 orchestration/locks/
 orchestration/pairs/
-!orchestration/plugin/
-!orchestration/agent/
 
 # Worker worktrees (runtime only)
 worktrees/
-orchestration/
 
 # Kilo runtime data (plans, sessions, node_modules)
 .kilo/

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ worktrees/
 
 # Kilo runtime data (plans, sessions, node_modules)
 .kilo/
+orchestration/

--- a/binary/Cargo.toml
+++ b/binary/Cargo.toml
@@ -45,6 +45,3 @@ pair-harness    = { path = "../crates/pair-harness" }
 [dev-dependencies]
 mockito = "1"
 tempfile = "3"
-
-[profile.release]
-opt-level = 3

--- a/binary/Cargo.toml
+++ b/binary/Cargo.toml
@@ -45,3 +45,6 @@ pair-harness    = { path = "../crates/pair-harness" }
 [dev-dependencies]
 mockito = "1"
 tempfile = "3"
+
+[profile.release]
+opt-level = 3

--- a/binary/src/bin/agentflow.rs
+++ b/binary/src/bin/agentflow.rs
@@ -68,7 +68,15 @@ async fn main() -> Result<()> {
             }
             other => {
                 eprintln!("Unknown argument: {}", other);
-                std::process::exit(1);
+                eprintln!("openflows (agentflow) — Autonomous AI Development Team");
+                eprintln!();
+                eprintln!("USAGE:");
+                eprintln!("  openflows                          Start the orchestration loop");
+                eprintln!(
+                    "  openflows --reset-orchestration    Reset orchestration files to defaults"
+                );
+                eprintln!("  openflows --help                   Show this help message");
+                std::process::exit(0);
             }
         }
     }

--- a/binary/src/bin/agentflow.rs
+++ b/binary/src/bin/agentflow.rs
@@ -48,7 +48,10 @@ async fn main() -> Result<()> {
                 let _ = load_env()?;
                 let resolver = openflows::orchestration::OrchestrationResolver::new()?;
                 let orch_dir = resolver.reset_orchestration_dir()?;
-                println!("Orchestration files reset to bundled defaults at: {}", orch_dir.display());
+                println!(
+                    "Orchestration files reset to bundled defaults at: {}",
+                    orch_dir.display()
+                );
                 println!("Version: {}", env!("CARGO_PKG_VERSION"));
                 return Ok(());
             }
@@ -57,7 +60,9 @@ async fn main() -> Result<()> {
                 eprintln!();
                 eprintln!("USAGE:");
                 eprintln!("  openflows                          Start the orchestration loop");
-                eprintln!("  openflows --reset-orchestration    Reset orchestration files to defaults");
+                eprintln!(
+                    "  openflows --reset-orchestration    Reset orchestration files to defaults"
+                );
                 eprintln!("  openflows --help                   Show this help message");
                 std::process::exit(0);
             }

--- a/binary/src/bin/agentflow.rs
+++ b/binary/src/bin/agentflow.rs
@@ -40,6 +40,34 @@ fn load_env() -> anyhow::Result<std::path::PathBuf> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() > 1 {
+        match args[1].as_str() {
+            "--reset-orchestration" => {
+                eprintln!("Loading environment...");
+                let _ = load_env()?;
+                let resolver = openflows::orchestration::OrchestrationResolver::new()?;
+                let orch_dir = resolver.reset_orchestration_dir()?;
+                println!("Orchestration files reset to bundled defaults at: {}", orch_dir.display());
+                println!("Version: {}", env!("CARGO_PKG_VERSION"));
+                return Ok(());
+            }
+            "--help" | "-h" => {
+                eprintln!("openflows (agentflow) — Autonomous AI Development Team");
+                eprintln!();
+                eprintln!("USAGE:");
+                eprintln!("  openflows                          Start the orchestration loop");
+                eprintln!("  openflows --reset-orchestration    Reset orchestration files to defaults");
+                eprintln!("  openflows --help                   Show this help message");
+                std::process::exit(0);
+            }
+            other => {
+                eprintln!("Unknown argument: {}", other);
+                std::process::exit(1);
+            }
+        }
+    }
+
     let env_path = load_env()?;
     if !env_path.as_os_str().is_empty() {
         eprintln!("Loaded environment from {}", env_path.display());
@@ -53,19 +81,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Startup diagnostics
-    // DEFAULT_CLI env var is checked later via Registry::effective_default_cli()
-    // Pre-load registry here just for startup log (full load happens after)
-    let registry_path = std::env::current_dir()
-        .ok()
-        .map(|p| p.join("orchestration").join("agent").join("registry.json"));
-    let default_cli = std::env::var("DEFAULT_CLI").unwrap_or_else(|_| {
-        registry_path
-            .as_ref()
-            .filter(|p| p.exists())
-            .and_then(|p| config::Registry::load(p).ok())
-            .map(|r| r.default_cli.clone())
-            .unwrap_or_else(|| "claude".to_string())
-    });
+    let default_cli = std::env::var("DEFAULT_CLI").unwrap_or_else(|_| "claude".to_string());
     let has_fireworks = std::env::var("FIREWORKS_API_KEY").is_ok();
     let has_openai = std::env::var("OPENAI_API_KEY").is_ok();
     let has_proxy = std::env::var("PROXY_URL").is_ok();
@@ -77,10 +93,6 @@ async fn main() -> Result<()> {
         info!("  LLM Mode: Codex + Fireworks (direct — no proxy needed)");
     } else if default_cli == "codex" && has_openai {
         let base_url = std::env::var("OPENAI_BASE_URL").ok();
-        // The endpoint mode (ResponsesApi vs ChatCompletions) is determined at
-        // runtime by probing /v1/responses — see process.rs::probe_endpoint_supports_responses().
-        // If the endpoint doesn't support /v1/responses, a local proxy is started
-        // to translate between the two formats.
         if let Some(url) = base_url {
             info!("  LLM Mode: Codex + OpenAI-compatible provider at {} (endpoint mode probed at startup)", url);
         } else {
@@ -116,39 +128,15 @@ async fn main() -> Result<()> {
 
     info!("Starting REAL End-to-End Orchestration (Event-Driven FORGE-SENTINEL Pairs + VESSEL)");
 
-    // 1. Validate Environment
-    // Resolve orchestrator_dir: search for orchestration/agent/registry.json in
-    // order: (1) next to the binary, (2) the binary's parent dir (npm layout),
-    // (3) OPENFLOWS_HOME, (4) current directory (dev mode).
-    let orchestrator_dir = {
-        let mut candidates = vec![
-            std::env::current_exe()
-                .ok()
-                .and_then(|p| p.parent().map(|p| p.to_path_buf())),
-            std::env::current_exe()
-                .ok()
-                .and_then(|p| p.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf())),
-        ];
-        let openflows_home = std::env::var("OPENFLOWS_HOME")
-            .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
-            .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
-            .ok();
-        if let Some(home) = openflows_home {
-            candidates.push(Some(std::path::PathBuf::from(home)));
-        }
-        candidates.push(std::env::current_dir().ok());
-        candidates
-            .into_iter()
-            .flatten()
-            .find(|dir| dir.join("orchestration/agent/registry.json").exists())
-            .ok_or_else(|| anyhow::anyhow!(
-                "Could not find orchestration/agent/registry.json in: binary dir, binary parent, OPENFLOWS_HOME, or current directory"
-            ))?
-    };
-    let registry_path = orchestrator_dir
-        .join("orchestration")
-        .join("agent")
-        .join("registry.json");
+    // 1. Resolve and ensure orchestration directory
+    use openflows::orchestration::OrchestrationResolver;
+    let resolver = OrchestrationResolver::new()?;
+    let orch_dir = resolver.ensure_orchestration_dir()?;
+    resolver.validate()?;
+
+    info!(dir = %orch_dir.display(), "Orchestration directory resolved");
+
+    let registry_path = resolver.registry_path();
     let registry = config::Registry::load(&registry_path)?;
     let github_token = registry
         .resolve_github_token("forge")
@@ -156,13 +144,11 @@ async fn main() -> Result<()> {
     let repo = std::env::var("GITHUB_REPOSITORY")
         .expect("GITHUB_REPOSITORY must be set (e.g. owner/repo)");
 
-    // Ensure LLM provider is set for AgentRunner
     if std::env::var("LLM_PROVIDER").is_err() {
         std::env::set_var("LLM_PROVIDER", "openai");
     }
 
     // 2. Clone/Update the target repository workspace
-    // Use ~/.agentflow/workspaces as base directory for all workspaces
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .expect("Could not determine home directory");
@@ -176,34 +162,21 @@ async fn main() -> Result<()> {
     info!(workspace = %workspace_dir.display(), "Target repository workspace ready");
 
     std::env::set_var("AGENTFLOW_WORKSPACE_ROOT", &workspace_dir);
-
-    // Set ORCHESTRATOR_DIR so pair harness can find the plugin
-    std::env::set_var("ORCHESTRATOR_DIR", &orchestrator_dir);
+    std::env::set_var("ORCHESTRATOR_DIR", resolver.orchestrator_dir());
 
     // 3. Initialize Nodes
-    // NEXUS: Orchestrator that assigns work
-    // ForgePairNode: Event-driven FORGE-SENTINEL pair with full review lifecycle
-    // VesselNode: Merge gatekeeper - polls CI, merges PRs, emits ticket_merged events
-    let persona_path = orchestrator_dir
-        .join("orchestration")
-        .join("agent")
-        .join("agents")
-        .join("nexus.agent.md");
-    let registry_path = orchestrator_dir
-        .join("orchestration")
-        .join("agent")
-        .join("registry.json");
-
-    let nexus = Arc::new(NexusNode::new(persona_path, registry_path.clone()));
+    let nexus_persona = resolver.persona_path("nexus.agent.md");
+    let nexus = Arc::new(NexusNode::new(nexus_persona, registry_path.clone()));
     let forge_pair = Arc::new(ForgePairNode::new_with_registry(
         &workspace_dir,
         registry_path.clone(),
     ));
     let vessel = Arc::new(VesselNode::from_env());
     let lore = if registry.get("lore").is_some() {
+        let lore_persona = resolver.persona_path("lore.agent.md");
         Some(Arc::new(LoreNode::new_with_registry(
             &workspace_dir,
-            orchestrator_dir.join("orchestration/agent/agents/lore.agent.md"),
+            lore_persona,
             registry_path.clone(),
         )?))
     } else {
@@ -212,19 +185,6 @@ async fn main() -> Result<()> {
     };
 
     // 4. Setup Flow with Routing
-    // The ForgePairNode handles the full FORGE-SENTINEL lifecycle:
-    // - FORGE writes PLAN.md -> SENTINEL reviews -> CONTRACT.md
-    // - FORGE implements segments -> SENTINEL evaluates -> segment-N-eval.md
-    // - SENTINEL final review -> final-review.md
-    // - FORGE opens PR -> STATUS.json
-    //
-    // VesselNode handles the merge gate:
-    // - Polls CI status until terminal (success/failure/timeout)
-    // - Detects merge conflicts early via GitHub's mergeable field
-    // - Attempts conflict resolution (GitHub update-branch or local rebase)
-    // - Routes unresolvable conflicts back to forge_pair for rework
-    // - Merges PR if CI green
-    // - Emits ticket_merged event for dependency resolution
     let mut flow = Flow::new("nexus")
         .add_node(
             "nexus",
@@ -275,8 +235,6 @@ async fn main() -> Result<()> {
     // 5. Initialize Shared Store
     let store = SharedStore::new_in_memory();
     store.set("repository", serde_json::json!(repo)).await;
-
-    // Initial tickets list - Nexus will fetch from GitHub if this is empty
     store.set(KEY_TICKETS, serde_json::json!([])).await;
     store.set(KEY_WORKER_SLOTS, serde_json::json!({})).await;
     store.set(KEY_PENDING_PRS, serde_json::json!([])).await;

--- a/binary/src/bundled.rs
+++ b/binary/src/bundled.rs
@@ -1,0 +1,98 @@
+use crate::orchestration::BundledFile;
+
+pub(crate) fn bundled_files() -> Vec<BundledFile> {
+    vec![
+        // Agent configuration
+        BundledFile { relative_path: "agent/registry.json", content: include_str!("../../orchestration/agent/registry.json") },
+        // Agent personas
+        BundledFile { relative_path: "agent/agents/nexus.agent.md", content: include_str!("../../orchestration/agent/agents/nexus.agent.md") },
+        BundledFile { relative_path: "agent/agents/forge.agent.md", content: include_str!("../../orchestration/agent/agents/forge.agent.md") },
+        BundledFile { relative_path: "agent/agents/sentinel.agent.md", content: include_str!("../../orchestration/agent/agents/sentinel.agent.md") },
+        BundledFile { relative_path: "agent/agents/vessel.agent.md", content: include_str!("../../orchestration/agent/agents/vessel.agent.md") },
+        BundledFile { relative_path: "agent/agents/lore.agent.md", content: include_str!("../../orchestration/agent/agents/lore.agent.md") },
+        // Agent standards
+        BundledFile { relative_path: "agent/standards/CODING.md", content: include_str!("../../orchestration/agent/standards/CODING.md") },
+        BundledFile { relative_path: "agent/standards/REVIEW.md", content: include_str!("../../orchestration/agent/standards/REVIEW.md") },
+        BundledFile { relative_path: "agent/standards/SECURITY.md", content: include_str!("../../orchestration/agent/standards/SECURITY.md") },
+        // Plugin config
+        BundledFile { relative_path: "plugin/plugin.json", content: include_str!("../../orchestration/plugin/plugin.json") },
+        BundledFile { relative_path: "plugin/.codex-plugin/plugin.json", content: include_str!("../../orchestration/plugin/.codex-plugin/plugin.json") },
+        // Plugin commands
+        BundledFile { relative_path: "plugin/commands/assign.md", content: include_str!("../../orchestration/plugin/commands/assign.md") },
+        BundledFile { relative_path: "plugin/commands/check-ci.md", content: include_str!("../../orchestration/plugin/commands/check-ci.md") },
+        BundledFile { relative_path: "plugin/commands/document-pr.md", content: include_str!("../../orchestration/plugin/commands/document-pr.md") },
+        BundledFile { relative_path: "plugin/commands/gate-approve.md", content: include_str!("../../orchestration/plugin/commands/gate-approve.md") },
+        BundledFile { relative_path: "plugin/commands/handoff.md", content: include_str!("../../orchestration/plugin/commands/handoff.md") },
+        BundledFile { relative_path: "plugin/commands/merge.md", content: include_str!("../../orchestration/plugin/commands/merge.md") },
+        BundledFile { relative_path: "plugin/commands/plan.md", content: include_str!("../../orchestration/plugin/commands/plan.md") },
+        BundledFile { relative_path: "plugin/commands/segment-done.md", content: include_str!("../../orchestration/plugin/commands/segment-done.md") },
+        BundledFile { relative_path: "plugin/commands/status-check.md", content: include_str!("../../orchestration/plugin/commands/status-check.md") },
+        BundledFile { relative_path: "plugin/commands/status.md", content: include_str!("../../orchestration/plugin/commands/status.md") },
+        BundledFile { relative_path: "plugin/commands/update-changelog.md", content: include_str!("../../orchestration/plugin/commands/update-changelog.md") },
+        // Plugin hooks
+        BundledFile { relative_path: "plugin/hooks/hooks.json", content: include_str!("../../orchestration/plugin/hooks/hooks.json") },
+        BundledFile { relative_path: "plugin/hooks/forge/post_write_lint.sh", content: include_str!("../../orchestration/plugin/hooks/forge/post_write_lint.sh") },
+        BundledFile { relative_path: "plugin/hooks/forge/pre_bash_guard.sh", content: include_str!("../../orchestration/plugin/hooks/forge/pre_bash_guard.sh") },
+        BundledFile { relative_path: "plugin/hooks/forge/pre_compact_handoff.sh", content: include_str!("../../orchestration/plugin/hooks/forge/pre_compact_handoff.sh") },
+        BundledFile { relative_path: "plugin/hooks/forge/pre_write_check.sh", content: include_str!("../../orchestration/plugin/hooks/forge/pre_write_check.sh") },
+        BundledFile { relative_path: "plugin/hooks/forge/session_start.sh", content: include_str!("../../orchestration/plugin/hooks/forge/session_start.sh") },
+        BundledFile { relative_path: "plugin/hooks/forge/stop_require_artifact.sh", content: include_str!("../../orchestration/plugin/hooks/forge/stop_require_artifact.sh") },
+        BundledFile { relative_path: "plugin/hooks/forge/subagent_start.sh", content: include_str!("../../orchestration/plugin/hooks/forge/subagent_start.sh") },
+        BundledFile { relative_path: "plugin/hooks/forge/subagent_stop.sh", content: include_str!("../../orchestration/plugin/hooks/forge/subagent_stop.sh") },
+        BundledFile { relative_path: "plugin/hooks/lore/session-start.sh", content: include_str!("../../orchestration/plugin/hooks/lore/session-start.sh") },
+        BundledFile { relative_path: "plugin/hooks/nexus/init-session.sh", content: include_str!("../../orchestration/plugin/hooks/nexus/init-session.sh") },
+        BundledFile { relative_path: "plugin/hooks/nexus/log-decision.sh", content: include_str!("../../orchestration/plugin/hooks/nexus/log-decision.sh") },
+        BundledFile { relative_path: "plugin/hooks/sentinel/post_write_validate.sh", content: include_str!("../../orchestration/plugin/hooks/sentinel/post_write_validate.sh") },
+        BundledFile { relative_path: "plugin/hooks/sentinel/pre_bash_readonly_guard.sh", content: include_str!("../../orchestration/plugin/hooks/sentinel/pre_bash_readonly_guard.sh") },
+        BundledFile { relative_path: "plugin/hooks/sentinel/session_start.sh", content: include_str!("../../orchestration/plugin/hooks/sentinel/session_start.sh") },
+        BundledFile { relative_path: "plugin/hooks/sentinel/stop_require_eval.sh", content: include_str!("../../orchestration/plugin/hooks/sentinel/stop_require_eval.sh") },
+        BundledFile { relative_path: "plugin/hooks/sentinel/subagent_start.sh", content: include_str!("../../orchestration/plugin/hooks/sentinel/subagent_start.sh") },
+        BundledFile { relative_path: "plugin/hooks/sentinel/subagent_stop.sh", content: include_str!("../../orchestration/plugin/hooks/sentinel/subagent_stop.sh") },
+        BundledFile { relative_path: "plugin/hooks/vessel/log-merge-status.sh", content: include_str!("../../orchestration/plugin/hooks/vessel/log-merge-status.sh") },
+        BundledFile { relative_path: "plugin/hooks/vessel/session-start.sh", content: include_str!("../../orchestration/plugin/hooks/vessel/session-start.sh") },
+        // Plugin MCP
+        BundledFile { relative_path: "plugin/mcp/mcp.json.template", content: include_str!("../../orchestration/plugin/mcp/mcp.json.template") },
+        // Plugin skills - forge
+        BundledFile { relative_path: "plugin/skills/forge-algorithmic-art/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-algorithmic-art/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/forge-canvas-design/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-canvas-design/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/forge-coding/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-coding/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/forge-frontend-design/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-frontend-design/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/forge-mcp-builder/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-mcp-builder/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/forge-planning/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-planning/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/forge-skill-creator/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-skill-creator/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/forge-web-artifacts-builder/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-web-artifacts-builder/SKILL.md") },
+        // Plugin skills - lore
+        BundledFile { relative_path: "plugin/skills/lore-brand-guidelines/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-brand-guidelines/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/lore-changelog/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-changelog/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/lore-doc-coauthoring/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-doc-coauthoring/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/lore-documentation/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-documentation/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/lore-docx/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-docx/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/lore-pdf/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-pdf/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/lore-pptx/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-pptx/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/lore-theme-factory/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-theme-factory/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/lore-xlsx/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-xlsx/SKILL.md") },
+        // Plugin skills - nexus
+        BundledFile { relative_path: "plugin/skills/nexus-doc-coauthoring/SKILL.md", content: include_str!("../../orchestration/plugin/skills/nexus-doc-coauthoring/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/nexus-internal-comms/SKILL.md", content: include_str!("../../orchestration/plugin/skills/nexus-internal-comms/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/nexus-orchestration/SKILL.md", content: include_str!("../../orchestration/plugin/skills/nexus-orchestration/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/nexus-skill-creator/SKILL.md", content: include_str!("../../orchestration/plugin/skills/nexus-skill-creator/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/nexus-slack-gif-creator/SKILL.md", content: include_str!("../../orchestration/plugin/skills/nexus-slack-gif-creator/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/nexus-triage/SKILL.md", content: include_str!("../../orchestration/plugin/skills/nexus-triage/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/nexus-xlsx/SKILL.md", content: include_str!("../../orchestration/plugin/skills/nexus-xlsx/SKILL.md") },
+        // Plugin skills - sentinel
+        BundledFile { relative_path: "plugin/skills/sentinel-algorithmic-art/SKILL.md", content: include_str!("../../orchestration/plugin/skills/sentinel-algorithmic-art/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/sentinel-criteria/SKILL.md", content: include_str!("../../orchestration/plugin/skills/sentinel-criteria/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/sentinel-frontend-design/SKILL.md", content: include_str!("../../orchestration/plugin/skills/sentinel-frontend-design/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/sentinel-review/SKILL.md", content: include_str!("../../orchestration/plugin/skills/sentinel-review/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/sentinel-webapp-testing/SKILL.md", content: include_str!("../../orchestration/plugin/skills/sentinel-webapp-testing/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/sentinel-web-artifacts-builder/SKILL.md", content: include_str!("../../orchestration/plugin/skills/sentinel-web-artifacts-builder/SKILL.md") },
+        // Plugin skills - shared & vessel
+        BundledFile { relative_path: "plugin/skills/shared-claude-api/SKILL.md", content: include_str!("../../orchestration/plugin/skills/shared-claude-api/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/vessel-ci-gate/SKILL.md", content: include_str!("../../orchestration/plugin/skills/vessel-ci-gate/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/vessel-internal-comms/SKILL.md", content: include_str!("../../orchestration/plugin/skills/vessel-internal-comms/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/vessel-mcp-builder/SKILL.md", content: include_str!("../../orchestration/plugin/skills/vessel-mcp-builder/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/vessel-merge-protocol/SKILL.md", content: include_str!("../../orchestration/plugin/skills/vessel-merge-protocol/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/vessel-pdf/SKILL.md", content: include_str!("../../orchestration/plugin/skills/vessel-pdf/SKILL.md") },
+        BundledFile { relative_path: "plugin/skills/vessel-webapp-testing/SKILL.md", content: include_str!("../../orchestration/plugin/skills/vessel-webapp-testing/SKILL.md") },
+    ]
+}

--- a/binary/src/bundled.rs
+++ b/binary/src/bundled.rs
@@ -3,96 +3,372 @@ use crate::orchestration::BundledFile;
 pub(crate) fn bundled_files() -> Vec<BundledFile> {
     vec![
         // Agent configuration
-        BundledFile { relative_path: "agent/registry.json", content: include_str!("../../orchestration/agent/registry.json") },
+        BundledFile {
+            relative_path: "agent/registry.json",
+            content: include_str!("../../orchestration/agent/registry.json"),
+        },
         // Agent personas
-        BundledFile { relative_path: "agent/agents/nexus.agent.md", content: include_str!("../../orchestration/agent/agents/nexus.agent.md") },
-        BundledFile { relative_path: "agent/agents/forge.agent.md", content: include_str!("../../orchestration/agent/agents/forge.agent.md") },
-        BundledFile { relative_path: "agent/agents/sentinel.agent.md", content: include_str!("../../orchestration/agent/agents/sentinel.agent.md") },
-        BundledFile { relative_path: "agent/agents/vessel.agent.md", content: include_str!("../../orchestration/agent/agents/vessel.agent.md") },
-        BundledFile { relative_path: "agent/agents/lore.agent.md", content: include_str!("../../orchestration/agent/agents/lore.agent.md") },
+        BundledFile {
+            relative_path: "agent/agents/nexus.agent.md",
+            content: include_str!("../../orchestration/agent/agents/nexus.agent.md"),
+        },
+        BundledFile {
+            relative_path: "agent/agents/forge.agent.md",
+            content: include_str!("../../orchestration/agent/agents/forge.agent.md"),
+        },
+        BundledFile {
+            relative_path: "agent/agents/sentinel.agent.md",
+            content: include_str!("../../orchestration/agent/agents/sentinel.agent.md"),
+        },
+        BundledFile {
+            relative_path: "agent/agents/vessel.agent.md",
+            content: include_str!("../../orchestration/agent/agents/vessel.agent.md"),
+        },
+        BundledFile {
+            relative_path: "agent/agents/lore.agent.md",
+            content: include_str!("../../orchestration/agent/agents/lore.agent.md"),
+        },
         // Agent standards
-        BundledFile { relative_path: "agent/standards/CODING.md", content: include_str!("../../orchestration/agent/standards/CODING.md") },
-        BundledFile { relative_path: "agent/standards/REVIEW.md", content: include_str!("../../orchestration/agent/standards/REVIEW.md") },
-        BundledFile { relative_path: "agent/standards/SECURITY.md", content: include_str!("../../orchestration/agent/standards/SECURITY.md") },
+        BundledFile {
+            relative_path: "agent/standards/CODING.md",
+            content: include_str!("../../orchestration/agent/standards/CODING.md"),
+        },
+        BundledFile {
+            relative_path: "agent/standards/REVIEW.md",
+            content: include_str!("../../orchestration/agent/standards/REVIEW.md"),
+        },
+        BundledFile {
+            relative_path: "agent/standards/SECURITY.md",
+            content: include_str!("../../orchestration/agent/standards/SECURITY.md"),
+        },
         // Plugin config
-        BundledFile { relative_path: "plugin/plugin.json", content: include_str!("../../orchestration/plugin/plugin.json") },
-        BundledFile { relative_path: "plugin/.codex-plugin/plugin.json", content: include_str!("../../orchestration/plugin/.codex-plugin/plugin.json") },
+        BundledFile {
+            relative_path: "plugin/plugin.json",
+            content: include_str!("../../orchestration/plugin/plugin.json"),
+        },
+        BundledFile {
+            relative_path: "plugin/.codex-plugin/plugin.json",
+            content: include_str!("../../orchestration/plugin/.codex-plugin/plugin.json"),
+        },
         // Plugin commands
-        BundledFile { relative_path: "plugin/commands/assign.md", content: include_str!("../../orchestration/plugin/commands/assign.md") },
-        BundledFile { relative_path: "plugin/commands/check-ci.md", content: include_str!("../../orchestration/plugin/commands/check-ci.md") },
-        BundledFile { relative_path: "plugin/commands/document-pr.md", content: include_str!("../../orchestration/plugin/commands/document-pr.md") },
-        BundledFile { relative_path: "plugin/commands/gate-approve.md", content: include_str!("../../orchestration/plugin/commands/gate-approve.md") },
-        BundledFile { relative_path: "plugin/commands/handoff.md", content: include_str!("../../orchestration/plugin/commands/handoff.md") },
-        BundledFile { relative_path: "plugin/commands/merge.md", content: include_str!("../../orchestration/plugin/commands/merge.md") },
-        BundledFile { relative_path: "plugin/commands/plan.md", content: include_str!("../../orchestration/plugin/commands/plan.md") },
-        BundledFile { relative_path: "plugin/commands/segment-done.md", content: include_str!("../../orchestration/plugin/commands/segment-done.md") },
-        BundledFile { relative_path: "plugin/commands/status-check.md", content: include_str!("../../orchestration/plugin/commands/status-check.md") },
-        BundledFile { relative_path: "plugin/commands/status.md", content: include_str!("../../orchestration/plugin/commands/status.md") },
-        BundledFile { relative_path: "plugin/commands/update-changelog.md", content: include_str!("../../orchestration/plugin/commands/update-changelog.md") },
+        BundledFile {
+            relative_path: "plugin/commands/assign.md",
+            content: include_str!("../../orchestration/plugin/commands/assign.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/commands/check-ci.md",
+            content: include_str!("../../orchestration/plugin/commands/check-ci.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/commands/document-pr.md",
+            content: include_str!("../../orchestration/plugin/commands/document-pr.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/commands/gate-approve.md",
+            content: include_str!("../../orchestration/plugin/commands/gate-approve.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/commands/handoff.md",
+            content: include_str!("../../orchestration/plugin/commands/handoff.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/commands/merge.md",
+            content: include_str!("../../orchestration/plugin/commands/merge.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/commands/plan.md",
+            content: include_str!("../../orchestration/plugin/commands/plan.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/commands/segment-done.md",
+            content: include_str!("../../orchestration/plugin/commands/segment-done.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/commands/status-check.md",
+            content: include_str!("../../orchestration/plugin/commands/status-check.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/commands/status.md",
+            content: include_str!("../../orchestration/plugin/commands/status.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/commands/update-changelog.md",
+            content: include_str!("../../orchestration/plugin/commands/update-changelog.md"),
+        },
         // Plugin hooks
-        BundledFile { relative_path: "plugin/hooks/hooks.json", content: include_str!("../../orchestration/plugin/hooks/hooks.json") },
-        BundledFile { relative_path: "plugin/hooks/forge/post_write_lint.sh", content: include_str!("../../orchestration/plugin/hooks/forge/post_write_lint.sh") },
-        BundledFile { relative_path: "plugin/hooks/forge/pre_bash_guard.sh", content: include_str!("../../orchestration/plugin/hooks/forge/pre_bash_guard.sh") },
-        BundledFile { relative_path: "plugin/hooks/forge/pre_compact_handoff.sh", content: include_str!("../../orchestration/plugin/hooks/forge/pre_compact_handoff.sh") },
-        BundledFile { relative_path: "plugin/hooks/forge/pre_write_check.sh", content: include_str!("../../orchestration/plugin/hooks/forge/pre_write_check.sh") },
-        BundledFile { relative_path: "plugin/hooks/forge/session_start.sh", content: include_str!("../../orchestration/plugin/hooks/forge/session_start.sh") },
-        BundledFile { relative_path: "plugin/hooks/forge/stop_require_artifact.sh", content: include_str!("../../orchestration/plugin/hooks/forge/stop_require_artifact.sh") },
-        BundledFile { relative_path: "plugin/hooks/forge/subagent_start.sh", content: include_str!("../../orchestration/plugin/hooks/forge/subagent_start.sh") },
-        BundledFile { relative_path: "plugin/hooks/forge/subagent_stop.sh", content: include_str!("../../orchestration/plugin/hooks/forge/subagent_stop.sh") },
-        BundledFile { relative_path: "plugin/hooks/lore/session-start.sh", content: include_str!("../../orchestration/plugin/hooks/lore/session-start.sh") },
-        BundledFile { relative_path: "plugin/hooks/nexus/init-session.sh", content: include_str!("../../orchestration/plugin/hooks/nexus/init-session.sh") },
-        BundledFile { relative_path: "plugin/hooks/nexus/log-decision.sh", content: include_str!("../../orchestration/plugin/hooks/nexus/log-decision.sh") },
-        BundledFile { relative_path: "plugin/hooks/sentinel/post_write_validate.sh", content: include_str!("../../orchestration/plugin/hooks/sentinel/post_write_validate.sh") },
-        BundledFile { relative_path: "plugin/hooks/sentinel/pre_bash_readonly_guard.sh", content: include_str!("../../orchestration/plugin/hooks/sentinel/pre_bash_readonly_guard.sh") },
-        BundledFile { relative_path: "plugin/hooks/sentinel/session_start.sh", content: include_str!("../../orchestration/plugin/hooks/sentinel/session_start.sh") },
-        BundledFile { relative_path: "plugin/hooks/sentinel/stop_require_eval.sh", content: include_str!("../../orchestration/plugin/hooks/sentinel/stop_require_eval.sh") },
-        BundledFile { relative_path: "plugin/hooks/sentinel/subagent_start.sh", content: include_str!("../../orchestration/plugin/hooks/sentinel/subagent_start.sh") },
-        BundledFile { relative_path: "plugin/hooks/sentinel/subagent_stop.sh", content: include_str!("../../orchestration/plugin/hooks/sentinel/subagent_stop.sh") },
-        BundledFile { relative_path: "plugin/hooks/vessel/log-merge-status.sh", content: include_str!("../../orchestration/plugin/hooks/vessel/log-merge-status.sh") },
-        BundledFile { relative_path: "plugin/hooks/vessel/session-start.sh", content: include_str!("../../orchestration/plugin/hooks/vessel/session-start.sh") },
+        BundledFile {
+            relative_path: "plugin/hooks/hooks.json",
+            content: include_str!("../../orchestration/plugin/hooks/hooks.json"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/forge/post_write_lint.sh",
+            content: include_str!("../../orchestration/plugin/hooks/forge/post_write_lint.sh"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/forge/pre_bash_guard.sh",
+            content: include_str!("../../orchestration/plugin/hooks/forge/pre_bash_guard.sh"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/forge/pre_compact_handoff.sh",
+            content: include_str!("../../orchestration/plugin/hooks/forge/pre_compact_handoff.sh"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/forge/pre_write_check.sh",
+            content: include_str!("../../orchestration/plugin/hooks/forge/pre_write_check.sh"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/forge/session_start.sh",
+            content: include_str!("../../orchestration/plugin/hooks/forge/session_start.sh"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/forge/stop_require_artifact.sh",
+            content: include_str!(
+                "../../orchestration/plugin/hooks/forge/stop_require_artifact.sh"
+            ),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/forge/subagent_start.sh",
+            content: include_str!("../../orchestration/plugin/hooks/forge/subagent_start.sh"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/forge/subagent_stop.sh",
+            content: include_str!("../../orchestration/plugin/hooks/forge/subagent_stop.sh"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/lore/session-start.sh",
+            content: include_str!("../../orchestration/plugin/hooks/lore/session-start.sh"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/nexus/init-session.sh",
+            content: include_str!("../../orchestration/plugin/hooks/nexus/init-session.sh"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/nexus/log-decision.sh",
+            content: include_str!("../../orchestration/plugin/hooks/nexus/log-decision.sh"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/sentinel/post_write_validate.sh",
+            content: include_str!(
+                "../../orchestration/plugin/hooks/sentinel/post_write_validate.sh"
+            ),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/sentinel/pre_bash_readonly_guard.sh",
+            content: include_str!(
+                "../../orchestration/plugin/hooks/sentinel/pre_bash_readonly_guard.sh"
+            ),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/sentinel/session_start.sh",
+            content: include_str!("../../orchestration/plugin/hooks/sentinel/session_start.sh"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/sentinel/stop_require_eval.sh",
+            content: include_str!("../../orchestration/plugin/hooks/sentinel/stop_require_eval.sh"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/sentinel/subagent_start.sh",
+            content: include_str!("../../orchestration/plugin/hooks/sentinel/subagent_start.sh"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/sentinel/subagent_stop.sh",
+            content: include_str!("../../orchestration/plugin/hooks/sentinel/subagent_stop.sh"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/vessel/log-merge-status.sh",
+            content: include_str!("../../orchestration/plugin/hooks/vessel/log-merge-status.sh"),
+        },
+        BundledFile {
+            relative_path: "plugin/hooks/vessel/session-start.sh",
+            content: include_str!("../../orchestration/plugin/hooks/vessel/session-start.sh"),
+        },
         // Plugin MCP
-        BundledFile { relative_path: "plugin/mcp/mcp.json.template", content: include_str!("../../orchestration/plugin/mcp/mcp.json.template") },
+        BundledFile {
+            relative_path: "plugin/mcp/mcp.json.template",
+            content: include_str!("../../orchestration/plugin/mcp/mcp.json.template"),
+        },
         // Plugin skills - forge
-        BundledFile { relative_path: "plugin/skills/forge-algorithmic-art/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-algorithmic-art/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/forge-canvas-design/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-canvas-design/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/forge-coding/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-coding/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/forge-frontend-design/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-frontend-design/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/forge-mcp-builder/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-mcp-builder/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/forge-planning/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-planning/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/forge-skill-creator/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-skill-creator/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/forge-web-artifacts-builder/SKILL.md", content: include_str!("../../orchestration/plugin/skills/forge-web-artifacts-builder/SKILL.md") },
+        BundledFile {
+            relative_path: "plugin/skills/forge-algorithmic-art/SKILL.md",
+            content: include_str!(
+                "../../orchestration/plugin/skills/forge-algorithmic-art/SKILL.md"
+            ),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/forge-canvas-design/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/forge-canvas-design/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/forge-coding/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/forge-coding/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/forge-frontend-design/SKILL.md",
+            content: include_str!(
+                "../../orchestration/plugin/skills/forge-frontend-design/SKILL.md"
+            ),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/forge-mcp-builder/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/forge-mcp-builder/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/forge-planning/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/forge-planning/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/forge-skill-creator/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/forge-skill-creator/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/forge-web-artifacts-builder/SKILL.md",
+            content: include_str!(
+                "../../orchestration/plugin/skills/forge-web-artifacts-builder/SKILL.md"
+            ),
+        },
         // Plugin skills - lore
-        BundledFile { relative_path: "plugin/skills/lore-brand-guidelines/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-brand-guidelines/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/lore-changelog/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-changelog/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/lore-doc-coauthoring/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-doc-coauthoring/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/lore-documentation/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-documentation/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/lore-docx/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-docx/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/lore-pdf/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-pdf/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/lore-pptx/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-pptx/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/lore-theme-factory/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-theme-factory/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/lore-xlsx/SKILL.md", content: include_str!("../../orchestration/plugin/skills/lore-xlsx/SKILL.md") },
+        BundledFile {
+            relative_path: "plugin/skills/lore-brand-guidelines/SKILL.md",
+            content: include_str!(
+                "../../orchestration/plugin/skills/lore-brand-guidelines/SKILL.md"
+            ),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/lore-changelog/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/lore-changelog/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/lore-doc-coauthoring/SKILL.md",
+            content: include_str!(
+                "../../orchestration/plugin/skills/lore-doc-coauthoring/SKILL.md"
+            ),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/lore-documentation/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/lore-documentation/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/lore-docx/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/lore-docx/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/lore-pdf/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/lore-pdf/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/lore-pptx/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/lore-pptx/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/lore-theme-factory/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/lore-theme-factory/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/lore-xlsx/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/lore-xlsx/SKILL.md"),
+        },
         // Plugin skills - nexus
-        BundledFile { relative_path: "plugin/skills/nexus-doc-coauthoring/SKILL.md", content: include_str!("../../orchestration/plugin/skills/nexus-doc-coauthoring/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/nexus-internal-comms/SKILL.md", content: include_str!("../../orchestration/plugin/skills/nexus-internal-comms/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/nexus-orchestration/SKILL.md", content: include_str!("../../orchestration/plugin/skills/nexus-orchestration/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/nexus-skill-creator/SKILL.md", content: include_str!("../../orchestration/plugin/skills/nexus-skill-creator/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/nexus-slack-gif-creator/SKILL.md", content: include_str!("../../orchestration/plugin/skills/nexus-slack-gif-creator/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/nexus-triage/SKILL.md", content: include_str!("../../orchestration/plugin/skills/nexus-triage/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/nexus-xlsx/SKILL.md", content: include_str!("../../orchestration/plugin/skills/nexus-xlsx/SKILL.md") },
+        BundledFile {
+            relative_path: "plugin/skills/nexus-doc-coauthoring/SKILL.md",
+            content: include_str!(
+                "../../orchestration/plugin/skills/nexus-doc-coauthoring/SKILL.md"
+            ),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/nexus-internal-comms/SKILL.md",
+            content: include_str!(
+                "../../orchestration/plugin/skills/nexus-internal-comms/SKILL.md"
+            ),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/nexus-orchestration/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/nexus-orchestration/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/nexus-skill-creator/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/nexus-skill-creator/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/nexus-slack-gif-creator/SKILL.md",
+            content: include_str!(
+                "../../orchestration/plugin/skills/nexus-slack-gif-creator/SKILL.md"
+            ),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/nexus-triage/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/nexus-triage/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/nexus-xlsx/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/nexus-xlsx/SKILL.md"),
+        },
         // Plugin skills - sentinel
-        BundledFile { relative_path: "plugin/skills/sentinel-algorithmic-art/SKILL.md", content: include_str!("../../orchestration/plugin/skills/sentinel-algorithmic-art/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/sentinel-criteria/SKILL.md", content: include_str!("../../orchestration/plugin/skills/sentinel-criteria/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/sentinel-frontend-design/SKILL.md", content: include_str!("../../orchestration/plugin/skills/sentinel-frontend-design/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/sentinel-review/SKILL.md", content: include_str!("../../orchestration/plugin/skills/sentinel-review/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/sentinel-webapp-testing/SKILL.md", content: include_str!("../../orchestration/plugin/skills/sentinel-webapp-testing/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/sentinel-web-artifacts-builder/SKILL.md", content: include_str!("../../orchestration/plugin/skills/sentinel-web-artifacts-builder/SKILL.md") },
+        BundledFile {
+            relative_path: "plugin/skills/sentinel-algorithmic-art/SKILL.md",
+            content: include_str!(
+                "../../orchestration/plugin/skills/sentinel-algorithmic-art/SKILL.md"
+            ),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/sentinel-criteria/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/sentinel-criteria/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/sentinel-frontend-design/SKILL.md",
+            content: include_str!(
+                "../../orchestration/plugin/skills/sentinel-frontend-design/SKILL.md"
+            ),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/sentinel-review/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/sentinel-review/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/sentinel-webapp-testing/SKILL.md",
+            content: include_str!(
+                "../../orchestration/plugin/skills/sentinel-webapp-testing/SKILL.md"
+            ),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/sentinel-web-artifacts-builder/SKILL.md",
+            content: include_str!(
+                "../../orchestration/plugin/skills/sentinel-web-artifacts-builder/SKILL.md"
+            ),
+        },
         // Plugin skills - shared & vessel
-        BundledFile { relative_path: "plugin/skills/shared-claude-api/SKILL.md", content: include_str!("../../orchestration/plugin/skills/shared-claude-api/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/vessel-ci-gate/SKILL.md", content: include_str!("../../orchestration/plugin/skills/vessel-ci-gate/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/vessel-internal-comms/SKILL.md", content: include_str!("../../orchestration/plugin/skills/vessel-internal-comms/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/vessel-mcp-builder/SKILL.md", content: include_str!("../../orchestration/plugin/skills/vessel-mcp-builder/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/vessel-merge-protocol/SKILL.md", content: include_str!("../../orchestration/plugin/skills/vessel-merge-protocol/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/vessel-pdf/SKILL.md", content: include_str!("../../orchestration/plugin/skills/vessel-pdf/SKILL.md") },
-        BundledFile { relative_path: "plugin/skills/vessel-webapp-testing/SKILL.md", content: include_str!("../../orchestration/plugin/skills/vessel-webapp-testing/SKILL.md") },
+        BundledFile {
+            relative_path: "plugin/skills/shared-claude-api/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/shared-claude-api/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/vessel-ci-gate/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/vessel-ci-gate/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/vessel-internal-comms/SKILL.md",
+            content: include_str!(
+                "../../orchestration/plugin/skills/vessel-internal-comms/SKILL.md"
+            ),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/vessel-mcp-builder/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/vessel-mcp-builder/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/vessel-merge-protocol/SKILL.md",
+            content: include_str!(
+                "../../orchestration/plugin/skills/vessel-merge-protocol/SKILL.md"
+            ),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/vessel-pdf/SKILL.md",
+            content: include_str!("../../orchestration/plugin/skills/vessel-pdf/SKILL.md"),
+        },
+        BundledFile {
+            relative_path: "plugin/skills/vessel-webapp-testing/SKILL.md",
+            content: include_str!(
+                "../../orchestration/plugin/skills/vessel-webapp-testing/SKILL.md"
+            ),
+        },
     ]
 }

--- a/binary/src/lib.rs
+++ b/binary/src/lib.rs
@@ -1,2 +1,2 @@
-pub mod orchestration;
 mod bundled;
+pub mod orchestration;

--- a/binary/src/lib.rs
+++ b/binary/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod orchestration;
+mod bundled;

--- a/binary/src/main.rs
+++ b/binary/src/main.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use tracing::{info, warn};
 
 use crate::nodes::{ForgePairNode, LoreNode, NexusNode, VesselConfig, VesselNode};
+use openflows::orchestration::OrchestrationResolver;
 use crate::state::{
     Ticket, TicketStatus, WorkerSlot, WorkerStatus, ACTION_CI_FIX_NEEDED,
     ACTION_CONFLICTS_DETECTED, ACTION_DEPLOYED, ACTION_DEPLOY_FAILED, ACTION_DOCS_COMPLETE,
@@ -16,8 +17,47 @@ use crate::state::{
     ACTION_WORK_ASSIGNED, KEY_PENDING_PRS, KEY_TICKETS, KEY_WORKER_SLOTS,
 };
 
+fn print_usage_and_exit() -> ! {
+    eprintln!("openflows — Autonomous AI Development Team");
+    eprintln!();
+    eprintln!("USAGE:");
+    eprintln!("  openflows                  Start the orchestration loop");
+    eprintln!("  openflows --reset-orchestration  Reset all orchestration files to bundled defaults");
+    eprintln!("  openflows --help            Show this help message");
+    eprintln!();
+    eprintln!("The orchestration directory is resolved by searching:");
+    eprintln!("  1. Next to the binary");
+    eprintln!("  2. Binary's parent directory (npm layout)");
+    eprintln!("  3. OPENFLOWS_HOME (~/.openflows)");
+    eprintln!("  4. Current working directory");
+    eprintln!();
+    eprintln!("On first run, all missing orchestration files are written from");
+    eprintln!("built-in defaults. Use --reset-orchestration to overwrite all files.");
+    std::process::exit(0);
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() > 1 {
+        match args[1].as_str() {
+            "--reset-orchestration" => {
+                let resolver = OrchestrationResolver::new()?;
+                let orch_dir = resolver.reset_orchestration_dir()?;
+                println!("Orchestration files reset to bundled defaults at: {}", orch_dir.display());
+                println!("Version: {}", env!("CARGO_PKG_VERSION"));
+                return Ok(());
+            }
+            "--help" | "-h" => {
+                print_usage_and_exit();
+            }
+            other => {
+                eprintln!("Unknown argument: {}", other);
+                print_usage_and_exit();
+            }
+        }
+    }
+
     let openflows_home = std::env::var("OPENFLOWS_HOME")
         .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
         .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
@@ -119,42 +159,21 @@ async fn main() -> Result<()> {
         .await;
     store.set(KEY_PENDING_PRS, serde_json::json!([])).await;
 
-    // 4. Build Flow - use orchestration/agent directory for personas
-    // Resolve orchestrator_dir: search for orchestration/agent/registry.json in
-    // order: (1) next to the binary, (2) the binary's parent dir (npm layout),
-    // (3) OPENFLOWS_HOME, (4) current directory (dev mode).
-    let orchestrator_dir = {
-        let mut candidates = vec![
-            std::env::current_exe()
-                .ok()
-                .and_then(|p| p.parent().map(|p| p.to_path_buf())),
-            std::env::current_exe()
-                .ok()
-                .and_then(|p| p.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf())),
-        ];
-        let openflows_home = std::env::var("OPENFLOWS_HOME")
-            .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
-            .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
-            .ok();
-        if let Some(home) = openflows_home {
-            candidates.push(Some(std::path::PathBuf::from(home)));
-        }
-        candidates.push(std::env::current_dir().ok());
-        candidates
-            .into_iter()
-            .flatten()
-            .find(|dir| dir.join("orchestration/agent/registry.json").exists())
-            .ok_or_else(|| anyhow::anyhow!(
-                "Could not find orchestration/agent/registry.json in: binary dir, binary parent, OPENFLOWS_HOME, or current directory"
-            ))?
-    };
-    let registry_path = orchestrator_dir.join("orchestration/agent/registry.json");
+    // 4. Resolve and ensure orchestration directory is complete
+    //    Bundled files are embedded at compile time and materialized on disk if missing.
+    let resolver = OrchestrationResolver::new()?;
+    let orch_dir = resolver.ensure_orchestration_dir()?;
+    resolver.validate()?;
+
+    info!(dir = %orch_dir.display(), "Orchestration directory resolved");
+
+    let registry_path = resolver.registry_path();
     let registry = config::Registry::load(&registry_path)?;
-    
-    let nexus = Arc::new(NexusNode::new(
-        orchestrator_dir.join("orchestration/agent/agents/nexus.agent.md"),
-        registry_path.clone(),
-    ));
+
+    std::env::set_var("ORCHESTRATOR_DIR", resolver.orchestrator_dir());
+
+    let nexus_persona = resolver.persona_path("nexus.agent.md");
+    let nexus = Arc::new(NexusNode::new(nexus_persona, registry_path.clone()));
     let forge_pair = Arc::new(ForgePairNode::new_with_registry(
         &workspace_dir,
         registry_path.clone(),
@@ -166,9 +185,10 @@ async fn main() -> Result<()> {
         }),
     ));
     let lore = if registry.get("lore").is_some() {
+        let lore_persona = resolver.persona_path("lore.agent.md");
         Some(Arc::new(LoreNode::new_with_registry(
             &workspace_dir,
-            orchestrator_dir.join("orchestration/agent/agents/lore.agent.md"),
+            lore_persona,
             registry_path.clone(),
         )?))
     } else {

--- a/binary/src/orchestration.rs
+++ b/binary/src/orchestration.rs
@@ -71,6 +71,11 @@ impl OrchestrationResolver {
 
     pub fn ensure_orchestration_dir(&self) -> Result<std::path::PathBuf> {
         let orch_dir = self.orchestrator_dir.join("orchestration");
+
+        // Read the previously recorded version BEFORE writing anything,
+        // so we can detect stale on-disk files.
+        let disk_version = self.read_disk_version(&orch_dir);
+
         let mut written = 0usize;
 
         for file in bundled_files() {
@@ -99,16 +104,15 @@ impl OrchestrationResolver {
             );
         }
 
-        let disk_version = self.read_disk_version(&orch_dir);
         if let Some(ref dv) = disk_version {
             if dv != ORCHESTRATION_VERSION {
                 warn!(
                     disk_version = %dv,
                     bundled_version = ORCHESTRATION_VERSION,
                     dir = %orch_dir.display(),
-                    "Orchestration files on disk are from an older version. \
-                     Run 'openflows --reset-orchestration' to update them, \
-                     or edit them manually at your own risk."
+                    "Orchestration files on disk are from an older version ({}). \
+                     Run 'openflows --reset-orchestration' to update them.",
+                    dv
                 );
             }
         }
@@ -119,7 +123,6 @@ impl OrchestrationResolver {
     pub fn reset_orchestration_dir(&self) -> Result<std::path::PathBuf> {
         let orch_dir = self.orchestrator_dir.join("orchestration");
         let mut written = 0usize;
-        let skipped_custom = 0usize;
 
         for file in bundled_files() {
             let target = orch_dir.join(file.relative_path);
@@ -137,7 +140,6 @@ impl OrchestrationResolver {
         info!(
             dir = %orch_dir.display(),
             written,
-            skipped_custom,
             version = ORCHESTRATION_VERSION,
             "Reset all orchestration files to bundled defaults"
         );

--- a/binary/src/orchestration.rs
+++ b/binary/src/orchestration.rs
@@ -56,14 +56,17 @@ impl OrchestrationResolver {
 
     fn write_version_file(&self, orch_dir: &std::path::Path) -> Result<()> {
         let version_path = orch_dir.join(".version");
-        std::fs::write(&version_path, ORCHESTRATION_VERSION)
-            .with_context(|| format!("Failed to write version file to {}", version_path.display()))?;
+        std::fs::write(&version_path, ORCHESTRATION_VERSION).with_context(|| {
+            format!("Failed to write version file to {}", version_path.display())
+        })?;
         Ok(())
     }
 
     fn read_disk_version(&self, orch_dir: &std::path::Path) -> Option<String> {
         let version_path = orch_dir.join(".version");
-        std::fs::read_to_string(version_path).ok().map(|s| s.trim().to_string())
+        std::fs::read_to_string(version_path)
+            .ok()
+            .map(|s| s.trim().to_string())
     }
 
     pub fn ensure_orchestration_dir(&self) -> Result<std::path::PathBuf> {
@@ -147,7 +150,8 @@ impl OrchestrationResolver {
     }
 
     pub fn registry_path(&self) -> std::path::PathBuf {
-        self.orchestrator_dir.join("orchestration/agent/registry.json")
+        self.orchestrator_dir
+            .join("orchestration/agent/registry.json")
     }
 
     pub fn persona_path(&self, filename: &str) -> std::path::PathBuf {
@@ -174,7 +178,8 @@ impl OrchestrationResolver {
                  Searched: {}\n\
                  Run 'openflows --reset-orchestration' to regenerate all files from defaults.",
                 registry.display(),
-                self.candidates.iter()
+                self.candidates
+                    .iter()
                     .map(|c| c.display().to_string())
                     .collect::<Vec<_>>()
                     .join(", ")

--- a/binary/src/orchestration.rs
+++ b/binary/src/orchestration.rs
@@ -89,6 +89,18 @@ impl OrchestrationResolver {
             }
             std::fs::write(&target, file.content)
                 .with_context(|| format!("Failed to write bundled file {}", target.display()))?;
+
+            // Shell scripts need executable permissions so the
+            // orchestration system can invoke them as hooks.
+            if file.relative_path.ends_with(".sh") {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755))
+                        .with_context(|| format!("Failed to set permissions on {}", target.display()))?;
+                }
+            }
+
             written += 1;
             info!(path = %target.display(), "Wrote bundled orchestration file");
         }
@@ -132,6 +144,16 @@ impl OrchestrationResolver {
             }
             std::fs::write(&target, file.content)
                 .with_context(|| format!("Failed to write bundled file {}", target.display()))?;
+
+            if file.relative_path.ends_with(".sh") {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755))
+                        .with_context(|| format!("Failed to set permissions on {}", target.display()))?;
+                }
+            }
+
             written += 1;
         }
 

--- a/binary/src/orchestration.rs
+++ b/binary/src/orchestration.rs
@@ -97,7 +97,9 @@ impl OrchestrationResolver {
                 {
                     use std::os::unix::fs::PermissionsExt;
                     std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755))
-                        .with_context(|| format!("Failed to set permissions on {}", target.display()))?;
+                        .with_context(|| {
+                            format!("Failed to set permissions on {}", target.display())
+                        })?;
                 }
             }
 
@@ -150,7 +152,9 @@ impl OrchestrationResolver {
                 {
                     use std::os::unix::fs::PermissionsExt;
                     std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755))
-                        .with_context(|| format!("Failed to set permissions on {}", target.display()))?;
+                        .with_context(|| {
+                            format!("Failed to set permissions on {}", target.display())
+                        })?;
                 }
             }
 

--- a/binary/src/orchestration.rs
+++ b/binary/src/orchestration.rs
@@ -1,0 +1,212 @@
+use anyhow::{Context, Result};
+use tracing::{info, warn};
+
+use crate::bundled::bundled_files;
+
+const ORCHESTRATION_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub struct BundledFile {
+    pub relative_path: &'static str,
+    pub content: &'static str,
+}
+
+pub struct OrchestrationResolver {
+    candidates: Vec<std::path::PathBuf>,
+    orchestrator_dir: std::path::PathBuf,
+}
+
+impl OrchestrationResolver {
+    pub fn new() -> Result<Self> {
+        let mut candidates = vec![
+            std::env::current_exe()
+                .ok()
+                .and_then(|p| p.parent().map(|p| p.to_path_buf())),
+            std::env::current_exe()
+                .ok()
+                .and_then(|p| p.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf())),
+        ];
+        let openflows_home = std::env::var("OPENFLOWS_HOME")
+            .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
+            .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
+            .ok();
+        if let Some(ref home) = openflows_home {
+            candidates.push(Some(std::path::PathBuf::from(home)));
+        }
+        candidates.push(std::env::current_dir().ok());
+
+        let candidates: Vec<std::path::PathBuf> = candidates.into_iter().flatten().collect();
+
+        let orchestrator_dir = candidates
+            .iter()
+            .find(|dir| dir.join("orchestration/agent/registry.json").exists())
+            .cloned()
+            .unwrap_or_else(|| {
+                let home = std::env::var("OPENFLOWS_HOME")
+                    .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
+                    .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
+                    .unwrap_or_else(|_| ".openflows".to_string());
+                std::path::PathBuf::from(home)
+            });
+
+        Ok(Self {
+            candidates,
+            orchestrator_dir,
+        })
+    }
+
+    fn write_version_file(&self, orch_dir: &std::path::Path) -> Result<()> {
+        let version_path = orch_dir.join(".version");
+        std::fs::write(&version_path, ORCHESTRATION_VERSION)
+            .with_context(|| format!("Failed to write version file to {}", version_path.display()))?;
+        Ok(())
+    }
+
+    fn read_disk_version(&self, orch_dir: &std::path::Path) -> Option<String> {
+        let version_path = orch_dir.join(".version");
+        std::fs::read_to_string(version_path).ok().map(|s| s.trim().to_string())
+    }
+
+    pub fn ensure_orchestration_dir(&self) -> Result<std::path::PathBuf> {
+        let orch_dir = self.orchestrator_dir.join("orchestration");
+        let mut written = 0usize;
+
+        for file in bundled_files() {
+            let target = orch_dir.join(file.relative_path);
+            if target.exists() {
+                continue;
+            }
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+            }
+            std::fs::write(&target, file.content)
+                .with_context(|| format!("Failed to write bundled file {}", target.display()))?;
+            written += 1;
+            info!(path = %target.display(), "Wrote bundled orchestration file");
+        }
+
+        self.write_version_file(&orch_dir)?;
+
+        if written > 0 {
+            info!(
+                dir = %orch_dir.display(),
+                written,
+                version = ORCHESTRATION_VERSION,
+                "Materialized bundled orchestration files"
+            );
+        }
+
+        let disk_version = self.read_disk_version(&orch_dir);
+        if let Some(ref dv) = disk_version {
+            if dv != ORCHESTRATION_VERSION {
+                warn!(
+                    disk_version = %dv,
+                    bundled_version = ORCHESTRATION_VERSION,
+                    dir = %orch_dir.display(),
+                    "Orchestration files on disk are from an older version. \
+                     Run 'openflows --reset-orchestration' to update them, \
+                     or edit them manually at your own risk."
+                );
+            }
+        }
+
+        Ok(orch_dir)
+    }
+
+    pub fn reset_orchestration_dir(&self) -> Result<std::path::PathBuf> {
+        let orch_dir = self.orchestrator_dir.join("orchestration");
+        let mut written = 0usize;
+        let skipped_custom = 0usize;
+
+        for file in bundled_files() {
+            let target = orch_dir.join(file.relative_path);
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+            }
+            std::fs::write(&target, file.content)
+                .with_context(|| format!("Failed to write bundled file {}", target.display()))?;
+            written += 1;
+        }
+
+        self.write_version_file(&orch_dir)?;
+
+        info!(
+            dir = %orch_dir.display(),
+            written,
+            skipped_custom,
+            version = ORCHESTRATION_VERSION,
+            "Reset all orchestration files to bundled defaults"
+        );
+
+        Ok(orch_dir)
+    }
+
+    pub fn orchestrator_dir(&self) -> &std::path::Path {
+        &self.orchestrator_dir
+    }
+
+    pub fn registry_path(&self) -> std::path::PathBuf {
+        self.orchestrator_dir.join("orchestration/agent/registry.json")
+    }
+
+    pub fn persona_path(&self, filename: &str) -> std::path::PathBuf {
+        let relative = format!("orchestration/agent/agents/{}", filename);
+        let direct = self.orchestrator_dir.join(&relative);
+        if direct.exists() {
+            return direct;
+        }
+        for candidate in &self.candidates {
+            let path = candidate.join(&relative);
+            if path.exists() {
+                return path;
+            }
+        }
+        direct
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        let orch_dir = self.orchestrator_dir.join("orchestration");
+        let registry = orch_dir.join("agent/registry.json");
+        if !registry.exists() {
+            anyhow::bail!(
+                "orchestration/agent/registry.json not found at {}\n\
+                 Searched: {}\n\
+                 Run 'openflows --reset-orchestration' to regenerate all files from defaults.",
+                registry.display(),
+                self.candidates.iter()
+                    .map(|c| c.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+
+        let required_personas = [
+            "nexus.agent.md",
+            "forge.agent.md",
+            "sentinel.agent.md",
+            "vessel.agent.md",
+        ];
+
+        let agents_dir = orch_dir.join("agent/agents");
+        let mut missing_personas = Vec::new();
+        for name in &required_personas {
+            if !agents_dir.join(name).exists() {
+                missing_personas.push(*name);
+            }
+        }
+
+        if !missing_personas.is_empty() {
+            anyhow::bail!(
+                "Missing required persona files in {}: {}\n\
+                 The orchestrator_dir resolved to: {}\n\
+                 Run 'openflows --reset-orchestration' to regenerate all files from defaults.",
+                agents_dir.display(),
+                missing_personas.join(", "),
+                self.orchestrator_dir.display()
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/crates/agent-nexus/src/lib.rs
+++ b/crates/agent-nexus/src/lib.rs
@@ -499,7 +499,17 @@ impl NexusNode {
     }
 
     async fn load_persona(&self) -> Result<AgentPersona> {
-        let content = tokio::fs::read_to_string(&self.persona_path).await?;
+        let content = tokio::fs::read_to_string(&self.persona_path)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to load nexus persona from {:?}: {}. \
+                     Ensure the orchestration/agent/agents/ directory with .agent.md files \
+                     is installed alongside the binary or in OPENFLOWS_HOME.",
+                    self.persona_path,
+                    e
+                )
+            })?;
         Ok(AgentPersona {
             id: "nexus".to_string(),
             role: "orchestrator".to_string(),

--- a/orchestration/agent/registry.json
+++ b/orchestration/agent/registry.json
@@ -1,0 +1,50 @@
+{
+  "default_cli": "claude",
+  "team": [
+    {
+      "id": "nexus",
+      "cli": "claude",
+      "active": true,
+      "instances": 1,
+      "model_backend": "anthropic/claude-haiku-4-5-20251001",
+      "routing_key": "nexus-key",
+      "github_token_env": "AGENT_NEXUS_GITHUB_TOKEN"
+    },
+    {
+      "id": "forge",
+      "cli": "claude",
+      "active": true,
+      "instances": 2,
+      "model_backend": "anthropic/claude-haiku-4-5-20251001",
+      "routing_key": "forge-key",
+      "github_token_env": "AGENT_FORGE_GITHUB_TOKEN"
+    },
+    {
+      "id": "sentinel",
+      "cli": "claude",
+      "active": true,
+      "instances": 1,
+      "model_backend": "anthropic/claude-haiku-4-5-20251001",
+      "routing_key": "sentinel-key",
+      "github_token_env": "AGENT_SENTINEL_GITHUB_TOKEN"
+    },
+    {                                                                                                           
+      "id": "vessel",
+      "cli": "claude",
+      "active": true,
+      "instances": 1,
+      "model_backend": "anthropic/claude-haiku-4-5-20251001",
+      "routing_key": "vessel-key",
+      "github_token_env": "AGENT_VESSEL_GITHUB_TOKEN"
+    },
+    {
+      "id": "lore",
+      "cli": "claude",
+      "active": false,
+      "instances": 1,
+      "model_backend": "anthropic/claude-haiku-4-5-20251001",
+      "routing_key": "lore-key",
+      "github_token_env": "AGENT_LORE_GITHUB_TOKEN"
+    }
+  ]
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -206,7 +206,6 @@ build_from_source() {
     info "Building OpenFlows from source..."
     local repo_dir
     repo_dir=$(mktemp -d)
-    trap "rm -rf '$repo_dir'" EXIT
 
     git clone --depth 1 "https://github.com/${REPO}.git" "$repo_dir"
     cd "$repo_dir"
@@ -220,6 +219,13 @@ build_from_source() {
             success "Built and installed ${bin}"
         fi
     done
+
+    if [ -d "orchestration" ]; then
+        cp -r orchestration "${INSTALL_DIR}/"
+        success "Installed orchestration config to ${INSTALL_DIR}/orchestration/"
+    fi
+
+    rm -rf "$repo_dir"
 }
 
 resolve_stable_tag() {
@@ -353,10 +359,11 @@ main() {
         echo ""
     fi
     echo "  Available commands:"
-    echo "    openflows         - Start orchestration"
-    echo "    openflows-setup   - Guided setup wizard"
-    echo "    openflows-dashboard - Live monitoring TUI"
-    echo "    openflows-doctor  - Diagnostic checks"
+    echo "    openflows                  - Start orchestration"
+    echo "    openflows --reset-orchestration - Reset config files to defaults"
+    echo "    openflows-setup           - Guided setup wizard"
+    echo "    openflows-dashboard       - Live monitoring TUI"
+    echo "    openflows-doctor          - Diagnostic checks"
     echo ""
     echo "  Next steps:"
     echo "    1. Run 'openflows-setup' to configure API keys"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -206,6 +206,7 @@ build_from_source() {
     info "Building OpenFlows from source..."
     local repo_dir
     repo_dir=$(mktemp -d)
+    trap "rm -rf '$repo_dir'" RETURN
 
     git clone --depth 1 "https://github.com/${REPO}.git" "$repo_dir"
     cd "$repo_dir"
@@ -224,8 +225,6 @@ build_from_source() {
         cp -r orchestration "${INSTALL_DIR}/"
         success "Installed orchestration config to ${INSTALL_DIR}/orchestration/"
     fi
-
-    rm -rf "$repo_dir"
 }
 
 resolve_stable_tag() {


### PR DESCRIPTION
… and version tracking

- OrchestrationResolver embeds all 80 files (personas, standards, plugins, hooks, skills, commands, MCP templates) via include_str!() in bundled.rs
- ensure_orchestration_dir() writes missing files from embedded content on startup
- .version file tracks bundled version (CARGO_PKG_VERSION); warns if on-disk is stale, suggests running openflows --reset-orchestration
- reset_orchestration_dir() overwrites ALL bundled files with embedded defaults (explicit opt-in via --reset-orchestration CLI flag)
- validate() checks required personas exist with clear error diagnostics
- persona_path() resolves from on-disk orchestrator dir, with fallback search
- Removed copy_persona_files() from setup wizard (now redundant)
- Removed fragile resolve_persona_path() fallback in main.rs
- Both openflows and agentflow binaries use OrchestrationResolver via lib crate
- lib.rs added to expose orchestration module to both binaries
- install.sh build_from_source() now copies orchestration/ directory
- agent-nexus load_persona() has better error message suggesting missing .md files
- ORCHESTRATOR_DIR env var set for pair-harness subprocesses