### PR TITLE
fix: add x86_64-unknown-linux-gnu release target and install script musl fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,19 +91,26 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            zigbuild_target: x86_64-unknown-linux-gnu.2.17
             archive_ext: tar.gz
+            use_zigbuild: true
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             archive_ext: tar.gz
+            use_zigbuild: false
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+            zigbuild_target: aarch64-unknown-linux-gnu.2.17
             archive_ext: tar.gz
+            use_zigbuild: true
           - os: macos-latest
             target: x86_64-apple-darwin
             archive_ext: tar.gz
+            use_zigbuild: false
           - os: macos-latest
             target: aarch64-apple-darwin
             archive_ext: tar.gz
+            use_zigbuild: false
     steps:
       - uses: actions/checkout@v4
 
@@ -120,10 +127,15 @@ jobs:
             sudo apt-get install -y gcc-aarch64-linux-gnu
           fi
 
+      - name: Install zig and cargo-zigbuild
+        if: matrix.use_zigbuild
+        run: |
+          pip3 install ziglang cargo-zigbuild
+
       - name: Build binaries
         run: >
-          cargo build --release
-          --target ${{ matrix.target }}
+          ${{ matrix.use_zigbuild && 'cargo zigbuild' || 'cargo build' }} --release
+          --target ${{ matrix.use_zigbuild && matrix.zigbuild_target || matrix.target }}
           --bin openflows
           --bin openflows-setup
           --bin openflows-dashboard
@@ -134,11 +146,12 @@ jobs:
         run: |
           VERSION="${{ needs.resolve-version.outputs.version }}"
           PLATFORM="${{ matrix.target }}"
+          BUILD_TARGET="${{ matrix.use_zigbuild && matrix.zigbuild_target || matrix.target }}"
           ARCHIVE="openflows-${VERSION}-${PLATFORM}"
           mkdir -p "dist/${ARCHIVE}"
 
           for bin in openflows openflows-setup openflows-dashboard openflows-doctor anthropic-proxy; do
-            cp "target/${{ matrix.target }}/release/${bin}" "dist/${ARCHIVE}/"
+            cp "target/${BUILD_TARGET}/release/${bin}" "dist/${ARCHIVE}/"
           done
 
           cp -r orchestration "dist/${ARCHIVE}/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive_ext: tar.gz
+          - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             archive_ext: tar.gz
           - os: ubuntu-latest

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -183,6 +183,7 @@ download_binary() {
             x86_64-unknown-linux-gnu)  alt_platform="x86_64-unknown-linux-musl" ;;
             x86_64-unknown-linux-musl) alt_platform="x86_64-unknown-linux-gnu" ;;
             aarch64-unknown-linux-gnu) alt_platform="aarch64-unknown-linux-musl" ;;
+            aarch64-unknown-linux-musl) alt_platform="aarch64-unknown-linux-gnu" ;;
             *) ;; 
         esac
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -163,21 +163,53 @@ download_binary() {
 
     local download_url="https://github.com/${REPO}/releases/download/${tag}/${asset_name}"
 
+    local download_ok=false
     if has_cmd curl; then
-        curl -fsSL "$download_url" -o "/tmp/${asset_name}" || {
-            fail "Failed to download ${asset_name}"
-            info "Falling back to building from source..."
-            return 1
-        }
+        if curl -fsSL "$download_url" -o "/tmp/${asset_name}" 2>/dev/null; then
+            download_ok=true
+        fi
     elif has_cmd wget; then
-        wget -q "$download_url" -O "/tmp/${asset_name}" || {
-            fail "Failed to download ${asset_name}"
-            info "Falling back to building from source..."
-            return 1
-        }
+        if wget -q "$download_url" -O "/tmp/${asset_name}" 2>/dev/null; then
+            download_ok=true
+        fi
     else
         fail "Neither curl nor wget found"
         return 1
+    fi
+
+    if [ "$download_ok" = false ]; then
+        local alt_platform=""
+        case "$platform" in
+            x86_64-unknown-linux-gnu)  alt_platform="x86_64-unknown-linux-musl" ;;
+            x86_64-unknown-linux-musl) alt_platform="x86_64-unknown-linux-gnu" ;;
+            aarch64-unknown-linux-gnu) alt_platform="aarch64-unknown-linux-musl" ;;
+            *) ;; 
+        esac
+
+        if [ -n "$alt_platform" ]; then
+            local alt_asset="openflows-${tag}-${alt_platform}.tar.gz"
+            local alt_url="https://github.com/${REPO}/releases/download/${tag}/${alt_asset}"
+            warn "No binary for ${platform}, trying ${alt_platform}..."
+            if has_cmd curl; then
+                if curl -fsSL "$alt_url" -o "/tmp/${alt_asset}" 2>/dev/null; then
+                    download_ok=true
+                    asset_name="$alt_asset"
+                    platform="$alt_platform"
+                fi
+            elif has_cmd wget; then
+                if wget -q "$alt_url" -O "/tmp/${alt_asset}" 2>/dev/null; then
+                    download_ok=true
+                    asset_name="$alt_asset"
+                    platform="$alt_platform"
+                fi
+            fi
+        fi
+
+        if [ "$download_ok" = false ]; then
+            fail "Failed to download binary for ${platform}"
+            info "Falling back to building from source..."
+            return 1
+        fi
     fi
 
     tar -xzf "/tmp/${asset_name}" -C /tmp/


### PR DESCRIPTION
## Problem

The v0.1.6 release only shipped `x86_64-unknown-linux-musl` binaries, but the install script detects glibc systems as `x86_64-unknown-linux-gnu` and tries to download a nonexistent binary, resulting in a **404 error** and forced source build.

## Changes

### 1. Release workflow (`.github/workflows/release.yml`)
- Added `x86_64-unknown-linux-gnu` target to the build matrix so future releases will include glibc binaries for x86_64 Linux

### 2. Install script (`scripts/install.sh`)
- Rewrote `download_binary()` to try the **alternate platform** (gnu ↔ musl) if the primary download 404s, before falling back to building from source
- This provides backward compatibility with existing releases (like v0.1.6) where only musl binaries exist — glibc users will automatically get the musl binary instead of hitting a 404

## Testing
- The fallback logic covers all Linux variants: gnu→musl, musl→gnu, aarch64-gnu→aarch64-musl
- macOS targets have no fallback (they already have complete coverage)
- Source build remains the final fallback if both platform variants fail