### PR TITLE
fix: prioritize OPENFLOWS_HOME registry and gracefully skip lore on token error

### DIFF
--- a/binary/src/bin/agentflow.rs
+++ b/binary/src/bin/agentflow.rs
@@ -187,11 +187,17 @@ async fn main() -> Result<()> {
     let vessel = Arc::new(VesselNode::from_env());
     let lore = if registry.get("lore").is_some() {
         let lore_persona = resolver.persona_path("lore.agent.md");
-        Some(Arc::new(LoreNode::new_with_registry(
+        match LoreNode::new_with_registry(
             &workspace_dir,
             lore_persona,
             registry_path.clone(),
-        )?))
+        ) {
+            Ok(node) => Some(Arc::new(node)),
+            Err(e) => {
+                warn!("lore agent is active but could not initialize — skipping: {}", e);
+                None
+            }
+        }
     } else {
         info!("lore agent is inactive — skipping lore node initialization");
         None

--- a/binary/src/bin/agentflow.rs
+++ b/binary/src/bin/agentflow.rs
@@ -187,14 +187,13 @@ async fn main() -> Result<()> {
     let vessel = Arc::new(VesselNode::from_env());
     let lore = if registry.get("lore").is_some() {
         let lore_persona = resolver.persona_path("lore.agent.md");
-        match LoreNode::new_with_registry(
-            &workspace_dir,
-            lore_persona,
-            registry_path.clone(),
-        ) {
+        match LoreNode::new_with_registry(&workspace_dir, lore_persona, registry_path.clone()) {
             Ok(node) => Some(Arc::new(node)),
             Err(e) => {
-                warn!("lore agent is active but could not initialize — skipping: {}", e);
+                warn!(
+                    "lore agent is active but could not initialize — skipping: {}",
+                    e
+                );
                 None
             }
         }

--- a/binary/src/main.rs
+++ b/binary/src/main.rs
@@ -186,11 +186,17 @@ async fn main() -> Result<()> {
     ));
     let lore = if registry.get("lore").is_some() {
         let lore_persona = resolver.persona_path("lore.agent.md");
-        Some(Arc::new(LoreNode::new_with_registry(
+        match LoreNode::new_with_registry(
             &workspace_dir,
             lore_persona,
             registry_path.clone(),
-        )?))
+        ) {
+            Ok(node) => Some(Arc::new(node)),
+            Err(e) => {
+                warn!("lore agent is active but could not initialize — skipping: {}", e);
+                None
+            }
+        }
     } else {
         info!("lore agent is inactive — skipping lore node initialization");
         None

--- a/binary/src/orchestration.rs
+++ b/binary/src/orchestration.rs
@@ -28,12 +28,18 @@ impl OrchestrationResolver {
         if let Some(ref home) = openflows_home_path {
             candidates.push(home.clone());
         }
-        if let Some(exe_path) = std::env::current_exe().ok().and_then(|p| p.parent().map(|p| p.to_path_buf())) {
+        if let Some(exe_path) = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+        {
             if !exe_path.as_os_str().is_empty() {
                 candidates.push(exe_path);
             }
         }
-        if let Some(exe_parent) = std::env::current_exe().ok().and_then(|p| p.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf())) {
+        if let Some(exe_parent) = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf()))
+        {
             if !exe_parent.as_os_str().is_empty() {
                 candidates.push(exe_parent);
             }
@@ -55,7 +61,9 @@ impl OrchestrationResolver {
                 let home = openflows_home_path.unwrap_or_else(|| {
                     let home = std::env::var("OPENFLOWS_HOME")
                         .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
-                        .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
+                        .or_else(|_| {
+                            std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h))
+                        })
                         .unwrap_or_else(|_| ".openflows".to_string());
                     std::path::PathBuf::from(home)
                 });

--- a/binary/src/orchestration.rs
+++ b/binary/src/orchestration.rs
@@ -17,36 +17,54 @@ pub struct OrchestrationResolver {
 
 impl OrchestrationResolver {
     pub fn new() -> Result<Self> {
-        let mut candidates = vec![
-            std::env::current_exe()
-                .ok()
-                .and_then(|p| p.parent().map(|p| p.to_path_buf())),
-            std::env::current_exe()
-                .ok()
-                .and_then(|p| p.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf())),
-        ];
         let openflows_home = std::env::var("OPENFLOWS_HOME")
             .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
             .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
             .ok();
-        if let Some(ref home) = openflows_home {
-            candidates.push(Some(std::path::PathBuf::from(home)));
+        let openflows_home_path = openflows_home.map(std::path::PathBuf::from);
+
+        let mut candidates: Vec<std::path::PathBuf> = Vec::new();
+
+        if let Some(ref home) = openflows_home_path {
+            candidates.push(home.clone());
         }
-        candidates.push(std::env::current_dir().ok());
+        if let Some(exe_path) = std::env::current_exe().ok().and_then(|p| p.parent().map(|p| p.to_path_buf())) {
+            if !exe_path.as_os_str().is_empty() {
+                candidates.push(exe_path);
+            }
+        }
+        if let Some(exe_parent) = std::env::current_exe().ok().and_then(|p| p.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf())) {
+            if !exe_parent.as_os_str().is_empty() {
+                candidates.push(exe_parent);
+            }
+        }
+        if let Ok(cwd) = std::env::current_dir() {
+            candidates.push(cwd);
+        }
 
-        let candidates: Vec<std::path::PathBuf> = candidates.into_iter().flatten().collect();
-
-        let orchestrator_dir = candidates
+        let (orchestrator_dir, found_registry) = candidates
             .iter()
-            .find(|dir| dir.join("orchestration/agent/registry.json").exists())
-            .cloned()
+            .find_map(|dir| {
+                if dir.join("orchestration/agent/registry.json").exists() {
+                    Some((dir.clone(), true))
+                } else {
+                    None
+                }
+            })
             .unwrap_or_else(|| {
-                let home = std::env::var("OPENFLOWS_HOME")
-                    .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
-                    .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
-                    .unwrap_or_else(|_| ".openflows".to_string());
-                std::path::PathBuf::from(home)
+                let home = openflows_home_path.unwrap_or_else(|| {
+                    let home = std::env::var("OPENFLOWS_HOME")
+                        .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
+                        .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
+                        .unwrap_or_else(|_| ".openflows".to_string());
+                    std::path::PathBuf::from(home)
+                });
+                (home, false)
             });
+
+        if found_registry {
+            info!(dir = %orchestrator_dir.display(), "Found existing registry at");
+        }
 
         Ok(Self {
             candidates,

--- a/binary/src/orchestration.rs
+++ b/binary/src/orchestration.rs
@@ -28,20 +28,16 @@ impl OrchestrationResolver {
         if let Some(ref home) = openflows_home_path {
             candidates.push(home.clone());
         }
-        if let Some(exe_path) = std::env::current_exe()
-            .ok()
-            .and_then(|p| p.parent().map(|p| p.to_path_buf()))
-        {
-            if !exe_path.as_os_str().is_empty() {
-                candidates.push(exe_path);
-            }
-        }
-        if let Some(exe_parent) = std::env::current_exe()
-            .ok()
-            .and_then(|p| p.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf()))
-        {
-            if !exe_parent.as_os_str().is_empty() {
-                candidates.push(exe_parent);
+        if let Ok(exe) = std::env::current_exe() {
+            if let Some(dir) = exe.parent() {
+                if !dir.as_os_str().is_empty() {
+                    candidates.push(dir.to_path_buf());
+                }
+                if let Some(parent) = dir.parent() {
+                    if !parent.as_os_str().is_empty() {
+                        candidates.push(parent.to_path_buf());
+                    }
+                }
             }
         }
         if let Ok(cwd) = std::env::current_dir() {


### PR DESCRIPTION
## Problem

Running `openflows` after setup crashes with `AGENT_LORE_GITHUB_TOKEN not set for agent lore` even when lore is deactivated in the setup wizard. This is caused by two bugs:

### Bug 1: Registry resolution priority
`OrchestrationResolver::new()` searched candidates in order `[binary_dir, binary_parent, OPENFLOWS_HOME, CWD]`. A stale bundled registry at the binary directory or CWD (with `lore.active: true`) could be found **before** the user's customized registry at `~/.openflows/` (with `lore.active: false`).

### Bug 2: Lore init crashes binary
When lore was active in a stale registry but its `AGENT_LORE_GITHUB_TOKEN` env var was not set, `LoreNode::new_with_registry()` propagated the error via `?`, crashing the entire process instead of gracefully degrading.

## Fix

1. **Registry priority**: Reordered candidate search to put `OPENFLOWS_HOME` first, so user customizations always take precedence over bundled/default registries at other paths.

2. **Graceful lore degradation**: Changed `LoreNode::new_with_registry()` calls from `?` to `match` — logs a warning and skips lore instead of crashing.

3. **Diagnostic logging**: Added `info!` log when an existing registry is found, making it easier to debug which registry path is being used.

4. **Empty path guard**: Filters out empty `PathBuf` entries from failed `current_exe()` calls to avoid phantom CWD matches.

## Changes
- `binary/src/orchestration.rs` — Reorder candidates, add found-registry log, filter empty paths
- `binary/src/bin/agentflow.rs` — Graceful lore init with `match` + warning
- `binary/src/main.rs` — Same graceful lore init as agentflow.rs

## Testing
- `cargo check --package openflows` passes
- `cargo test --package config --lib` — 39 tests pass