### PR TITLE
fix: preserve user registry.json during install and reset

### DIFF
--- a/binary/src/orchestration.rs
+++ b/binary/src/orchestration.rs
@@ -165,8 +165,14 @@ impl OrchestrationResolver {
 
             // Preserve user-customized registry.json so reset doesn't
             // discard agent toggles, model backends, etc. configured via setup.
+            // If registry.json is corrupted, users can delete it manually and
+            // re-run --reset-orchestration to restore defaults.
             if file.relative_path == "agent/registry.json" && target.exists() {
-                info!(path = %target.display(), "Preserving existing registry.json — manual edits will not be overwritten");
+                info!(
+                    path = %target.display(),
+                    "Preserving existing registry.json — manual edits will not be overwritten. \
+                     To reset it, delete this file and re-run --reset-orchestration."
+                );
                 continue;
             }
 

--- a/binary/src/orchestration.rs
+++ b/binary/src/orchestration.rs
@@ -162,6 +162,14 @@ impl OrchestrationResolver {
 
         for file in bundled_files() {
             let target = orch_dir.join(file.relative_path);
+
+            // Preserve user-customized registry.json so reset doesn't
+            // discard agent toggles, model backends, etc. configured via setup.
+            if file.relative_path == "agent/registry.json" && target.exists() {
+                info!(path = %target.display(), "Preserving existing registry.json — manual edits will not be overwritten");
+                continue;
+            }
+
             if let Some(parent) = target.parent() {
                 std::fs::create_dir_all(parent)
                     .with_context(|| format!("Failed to create directory {}", parent.display()))?;
@@ -189,7 +197,7 @@ impl OrchestrationResolver {
             dir = %orch_dir.display(),
             written,
             version = ORCHESTRATION_VERSION,
-            "Reset all orchestration files to bundled defaults"
+            "Reset orchestration files to bundled defaults (preserved user registry)"
         );
 
         Ok(orch_dir)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -154,6 +154,29 @@ ensure_ai_cli() {
     fi
 }
 
+# Copy orchestration files, preserving user-customized registry.json in OPENFLOWS_HOME.
+install_orchestration() {
+    local src_dir="$1"
+    local oh_dir="${OPENFLOWS_HOME:-$HOME/.openflows}"
+    local reg_path="orchestration/agent/registry.json"
+    local backup=""
+
+    if [ -f "${oh_dir}/${reg_path}" ]; then
+        backup=$(mktemp)
+        cp "${oh_dir}/${reg_path}" "$backup"
+    fi
+
+    cp -r "${src_dir}/orchestration" "${INSTALL_DIR}/"
+    success "Installed orchestration config to ${INSTALL_DIR}/orchestration/"
+
+    if [ -n "$backup" ] && [ -f "$backup" ]; then
+        mkdir -p "${oh_dir}/orchestration/agent"
+        cp "$backup" "${oh_dir}/${reg_path}"
+        rm -f "$backup"
+        info "Preserved existing registry.json in ${oh_dir} (run 'openflows-setup' to reconfigure)"
+    fi
+}
+
 download_binary() {
     local platform="$1"
     local tag="$2"
@@ -223,20 +246,7 @@ download_binary() {
     done
 
     if [ -d "${extract_dir}/orchestration" ]; then
-        # Back up user-customized registry.json before overwriting
-        local registry_backup=""
-        if [ -f "${INSTALL_DIR}/orchestration/agent/registry.json" ]; then
-            registry_backup=$(mktemp)
-            cp "${INSTALL_DIR}/orchestration/agent/registry.json" "$registry_backup"
-        fi
-        cp -r "${extract_dir}/orchestration" "${INSTALL_DIR}/"
-        # Restore user-customized registry.json if it existed before
-        if [ -n "$registry_backup" ] && [ -f "$registry_backup" ]; then
-            cp "$registry_backup" "${INSTALL_DIR}/orchestration/agent/registry.json"
-            rm -f "$registry_backup"
-            info "Preserved existing registry.json (run 'openflows-setup' to reconfigure)"
-        fi
-        success "Installed orchestration config to ${INSTALL_DIR}/orchestration/"
+        install_orchestration "${extract_dir}"
     fi
 
     rm -rf "${extract_dir}"
@@ -265,20 +275,7 @@ build_from_source() {
     done
 
     if [ -d "orchestration" ]; then
-        # Back up user-customized registry.json before overwriting
-        local registry_backup=""
-        if [ -f "${INSTALL_DIR}/orchestration/agent/registry.json" ]; then
-            registry_backup=$(mktemp)
-            cp "${INSTALL_DIR}/orchestration/agent/registry.json" "$registry_backup"
-        fi
-        cp -r orchestration "${INSTALL_DIR}/"
-        # Restore user-customized registry.json if it existed before
-        if [ -n "$registry_backup" ] && [ -f "$registry_backup" ]; then
-            cp "$registry_backup" "${INSTALL_DIR}/orchestration/agent/registry.json"
-            rm -f "$registry_backup"
-            info "Preserved existing registry.json (run 'openflows-setup' to reconfigure)"
-        fi
-        success "Installed orchestration config to ${INSTALL_DIR}/orchestration/"
+        install_orchestration "."
     fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -222,8 +222,20 @@ download_binary() {
         fi
     done
 
-    if [ -d "${extract_dir}/orchestration" ]; then
+if [ -d "${extract_dir}/orchestration" ]; then
+        # Back up user-customized registry.json before overwriting
+        local registry_backup=""
+        if [ -f "${INSTALL_DIR}/orchestration/agent/registry.json" ]; then
+            registry_backup=$(mktemp)
+            cp "${INSTALL_DIR}/orchestration/agent/registry.json" "$registry_backup"
+        fi
         cp -r "${extract_dir}/orchestration" "${INSTALL_DIR}/"
+        # Restore user-customized registry.json if it existed before
+        if [ -n "$registry_backup" ] && [ -f "$registry_backup" ]; then
+            cp "$registry_backup" "${INSTALL_DIR}/orchestration/agent/registry.json"
+            rm -f "$registry_backup"
+            info "Preserved existing registry.json (run 'openflows-setup' to reconfigure)"
+        fi
         success "Installed orchestration config to ${INSTALL_DIR}/orchestration/"
     fi
 
@@ -252,8 +264,20 @@ build_from_source() {
         fi
     done
 
-    if [ -d "orchestration" ]; then
+if [ -d "orchestration" ]; then
+        # Back up user-customized registry.json before overwriting
+        local registry_backup=""
+        if [ -f "${INSTALL_DIR}/orchestration/agent/registry.json" ]; then
+            registry_backup=$(mktemp)
+            cp "${INSTALL_DIR}/orchestration/agent/registry.json" "$registry_backup"
+        fi
         cp -r orchestration "${INSTALL_DIR}/"
+        # Restore user-customized registry.json if it existed before
+        if [ -n "$registry_backup" ] && [ -f "$registry_backup" ]; then
+            cp "$registry_backup" "${INSTALL_DIR}/orchestration/agent/registry.json"
+            rm -f "$registry_backup"
+            info "Preserved existing registry.json (run 'openflows-setup' to reconfigure)"
+        fi
         success "Installed orchestration config to ${INSTALL_DIR}/orchestration/"
     fi
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -222,7 +222,7 @@ download_binary() {
         fi
     done
 
-if [ -d "${extract_dir}/orchestration" ]; then
+    if [ -d "${extract_dir}/orchestration" ]; then
         # Back up user-customized registry.json before overwriting
         local registry_backup=""
         if [ -f "${INSTALL_DIR}/orchestration/agent/registry.json" ]; then
@@ -264,7 +264,7 @@ build_from_source() {
         fi
     done
 
-if [ -d "orchestration" ]; then
+    if [ -d "orchestration" ]; then
         # Back up user-customized registry.json before overwriting
         local registry_backup=""
         if [ -f "${INSTALL_DIR}/orchestration/agent/registry.json" ]; then


### PR DESCRIPTION
## Problem

When upgrading OpenFlows via `install.sh` or running `openflows --reset-orchestration`, the user's customized `registry.json` (with settings like `lore.active: false`) gets overwritten by the bundled default. This means agent toggles, model backends, and github_token_env settings configured via `openflows-setup` are lost.

## Fix

Two changes to preserve user customizations:

### 1. Install script (`scripts/install.sh`)
Both `download_binary()` and `build_from_source()` now back up the existing `registry.json` before copying the bundled orchestration directory, then restore it after. This prevents upgrades from clobbering user settings.

### 2. `--reset-orchestration` (`orchestration.rs`)
The reset command now skips `agent/registry.json` if it already exists on disk. It resets persona files, standards, hooks, etc. — but preserves the user's agent configuration.

## Complements PR #119
This pairs with the resolver priority fix from #119 (merged). Together they ensure:
- **Runtime**: `~/.openflows` is checked first for user customizations (#119)
- **Upgrade**: Install script preserves existing `registry.json` (this PR)  
- **Reset**: `--reset-orchestration` preserves `registry.json` (this PR)
- **Graceful**: Missing lore token logs a warning instead of crashing (#119)