### PR TITLE
fix: defense-in-depth for registry path, inactive agent tokens, and setup TUI

### DIFF
--- a/binary/src/orchestration.rs
+++ b/binary/src/orchestration.rs
@@ -50,9 +50,14 @@ impl OrchestrationResolver {
                 let registry = dir.join("orchestration/agent/registry.json");
                 if registry.exists() {
                     // Reject candidates that are inside an orchestration subdirectory
-                    // to prevent doubled paths like /foo/orchestration/agent/orchestration/agent/
-                    if dir.ends_with("orchestration/agent") || dir.ends_with("orchestration/agent/") {
-                        warn!(dir = %dir.display(), "Skipping candidate inside orchestration/agent — would cause doubled paths");
+                    // to prevent doubled paths like /foo/orchestration/orchestration/agent/
+                    let dir_str = dir.to_string_lossy();
+                    if dir_str.ends_with("/orchestration/agent")
+                        || dir_str.ends_with("/orchestration")
+                        || dir_str.ends_with("/orchestration/agent/")
+                        || dir_str.ends_with("/orchestration/")
+                    {
+                        warn!(dir = %dir.display(), "Skipping candidate inside orchestration subdirectory — would cause doubled paths");
                         return None;
                     }
                     Some((dir.clone(), true))

--- a/binary/src/orchestration.rs
+++ b/binary/src/orchestration.rs
@@ -47,7 +47,14 @@ impl OrchestrationResolver {
         let (orchestrator_dir, found_registry) = candidates
             .iter()
             .find_map(|dir| {
-                if dir.join("orchestration/agent/registry.json").exists() {
+                let registry = dir.join("orchestration/agent/registry.json");
+                if registry.exists() {
+                    // Reject candidates that are inside an orchestration subdirectory
+                    // to prevent doubled paths like /foo/orchestration/agent/orchestration/agent/
+                    if dir.ends_with("orchestration/agent") || dir.ends_with("orchestration/agent/") {
+                        warn!(dir = %dir.display(), "Skipping candidate inside orchestration/agent — would cause doubled paths");
+                        return None;
+                    }
                     Some((dir.clone(), true))
                 } else {
                     None

--- a/crates/agentflow-tui/src/setup/step_agents.rs
+++ b/crates/agentflow-tui/src/setup/step_agents.rs
@@ -42,10 +42,22 @@ impl AgentsStep {
     ) -> Result<()> {
         let mut agents: Vec<AgentConfig> = Vec::new();
 
-        let registry_path = std::env::current_dir()?
+        // Search for registry in OPENFLOWS_HOME first, then CWD
+        let openflows_home = std::env::var("OPENFLOWS_HOME")
+            .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
+            .unwrap_or_else(|_| ".openflows".to_string());
+        let registry_path = std::path::PathBuf::from(&openflows_home)
             .join("orchestration")
             .join("agent")
             .join("registry.json");
+        let registry_path = if registry_path.exists() {
+            registry_path
+        } else {
+            std::env::current_dir()?
+                .join("orchestration")
+                .join("agent")
+                .join("registry.json")
+        };
 
         // Discover models dynamically from the selected provider
         let discovered_models = match discover_models(config).await {

--- a/crates/agentflow-tui/src/setup/step_existing.rs
+++ b/crates/agentflow-tui/src/setup/step_existing.rs
@@ -112,10 +112,23 @@ impl ExistingConfigStep {
         }
 
         // Also load agents from registry.json
-        let registry_path = project_dir
+        // Search in OPENFLOWS_HOME first, then project_dir
+        let openflows_home = std::env::var("OPENFLOWS_HOME")
+            .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
+            .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{}/.openflows", h)))
+            .unwrap_or_else(|_| ".openflows".to_string());
+        let oh_registry = std::path::PathBuf::from(&openflows_home)
             .join("orchestration")
             .join("agent")
             .join("registry.json");
+        let registry_path = if oh_registry.exists() {
+            oh_registry
+        } else {
+            project_dir
+                .join("orchestration")
+                .join("agent")
+                .join("registry.json")
+        };
 
         if registry_path.exists() {
             if let Ok(registry) = config::Registry::load(&registry_path) {

--- a/crates/agentflow-tui/src/setup/step_github.rs
+++ b/crates/agentflow-tui/src/setup/step_github.rs
@@ -50,10 +50,22 @@ impl GitHubStep {
                 }
             }
         } else {
-            let registry_path = std::env::current_dir()?
+            // Search for registry in OPENFLOWS_HOME first, then CWD
+            let openflows_home = std::env::var("OPENFLOWS_HOME")
+                .or_else(|_| std::env::var("HOME").map(|h| format!("{}/.openflows", h)))
+                .unwrap_or_else(|_| ".openflows".to_string());
+            let oh_path = std::path::PathBuf::from(&openflows_home)
                 .join("orchestration")
                 .join("agent")
                 .join("registry.json");
+            let registry_path = if oh_path.exists() {
+                oh_path
+            } else {
+                std::env::current_dir()?
+                    .join("orchestration")
+                    .join("agent")
+                    .join("registry.json")
+            };
 
             if registry_path.exists() {
                 if let Ok(registry) = config::Registry::load(&registry_path) {

--- a/crates/config/src/registry.rs
+++ b/crates/config/src/registry.rs
@@ -249,6 +249,7 @@ impl Registry {
     /// Resolve GitHub token for a given agent./// If the agent has `github_token_env` set, reads from that env var.
     /// Falls back to `GITHUB_PERSONAL_ACCESS_TOKEN` for backward compatibility.
     /// Handles instance IDs (e.g., "forge-1") by stripping suffix to find base agent.
+    /// Returns an error if the agent exists but is inactive (not in active_agents).
     pub fn resolve_github_token(&self, agent_id: &str) -> Result<String> {
         let base_id = self.normalize_agent_id(agent_id);
         // Check if agent exists at all (active or inactive)
@@ -261,13 +262,18 @@ impl Registry {
                     .context("GITHUB_PERSONAL_ACCESS_TOKEN not set (fallback for agent without github_token_env)")?,
             },
             None => {
-                let msg = if entry_exists {
-                    format!("Agent '{}' exists but is inactive — set active: true in registry.json or remove agent from flow", base_id)
+                if entry_exists {
+                    // Agent exists but is inactive — this is an error, not a fallback case.
+                    // Silently returning the global PAT would mask misconfiguration.
+                    anyhow::bail!(
+                        "Agent '{}' exists but is inactive — set active: true in registry.json or remove agent from flow",
+                        base_id
+                    );
                 } else {
-                    format!("Agent '{}' not found in registry", base_id)
-                };
-                std::env::var("GITHUB_PERSONAL_ACCESS_TOKEN")
-                    .context(msg)?
+                    // Agent not found at all — fall back to global PAT for backward compat
+                    std::env::var("GITHUB_PERSONAL_ACCESS_TOKEN")
+                        .context(format!("Agent '{}' not found in registry", base_id))?
+                }
             }
         };
         Ok(token)

--- a/crates/config/src/registry.rs
+++ b/crates/config/src/registry.rs
@@ -274,9 +274,12 @@ impl Registry {
                 if entry_exists {
                     // Agent exists but is inactive — this is an error, not a fallback case.
                     // Silently returning the global PAT would mask misconfiguration.
+                    // Use the stripped id so the message matches the registry key
+                    // (e.g. "lore" rather than the instance id "lore-1").
+                    let display_id = if base_id == agent_id { stripped } else { base_id };
                     anyhow::bail!(
                         "Agent '{}' exists but is inactive — set active: true in registry.json or remove agent from flow",
-                        base_id
+                        display_id
                     );
                 } else {
                     // Agent not found at all — fall back to global PAT for backward compat

--- a/crates/config/src/registry.rs
+++ b/crates/config/src/registry.rs
@@ -255,7 +255,10 @@ impl Registry {
         // Existence check must also consider inactive agents, including the
         // suffix-stripped base (e.g. "lore-1" -> "lore"), since normalize_agent_id
         // only strips suffixes for *active* agents.
-        let stripped = agent_id.rsplit_once('-').map(|(b, _)| b).unwrap_or(agent_id);
+        let stripped = agent_id
+            .rsplit_once('-')
+            .map(|(b, _)| b)
+            .unwrap_or(agent_id);
         let entry_exists = self
             .team
             .iter()

--- a/crates/config/src/registry.rs
+++ b/crates/config/src/registry.rs
@@ -252,8 +252,14 @@ impl Registry {
     /// Returns an error if the agent exists but is inactive (not in active_agents).
     pub fn resolve_github_token(&self, agent_id: &str) -> Result<String> {
         let base_id = self.normalize_agent_id(agent_id);
-        // Check if agent exists at all (active or inactive)
-        let entry_exists = self.team.iter().any(|e| e.id == base_id);
+        // Existence check must also consider inactive agents, including the
+        // suffix-stripped base (e.g. "lore-1" -> "lore"), since normalize_agent_id
+        // only strips suffixes for *active* agents.
+        let stripped = agent_id.rsplit_once('-').map(|(b, _)| b).unwrap_or(agent_id);
+        let entry_exists = self
+            .team
+            .iter()
+            .any(|e| e.id == base_id || e.id == stripped);
         let token = match self.get(base_id) {
             Some(entry) => match &entry.github_token_env {
                 Some(env_var) => std::env::var(env_var)


### PR DESCRIPTION
## Problem

A full audit revealed several related bugs in the same class as the original LORE token crash:

### Bug 1: Doubled path still possible
`OrchestrationResolver` only rejected candidates ending in `orchestration/agent` but not just `orchestration`. If a user set `OPENFLOWS_HOME=/path/to/orchestration`, files would be written to `/path/to/orchestration/orchestration/agent/registry.json` — a doubled path.

### Bug 2: Inactive agents silently get global PAT
`resolve_github_token()` fell back to `GITHUB_PERSONAL_ACCESS_TOKEN` for inactive agents (which `get()` returns `None` for). This means if the global PAT existed, an inactive agent would still get a valid token — masking the misconfiguration. This is exactly the bug the user hit: lore was inactive in their customized registry, but a stale registry had it active, and the error message was confusing.

### Bug 3: Setup TUI reads from CWD instead of OPENFLOWS_HOME
All three setup steps (`step_agents`, `step_existing`, `step_github`) read `registry.json` from the current working directory only. If the user ran setup from a different directory than `~/.openflows`, they'd get stale bundled defaults instead of their customizations.

## Fix

1. **`orchestration.rs`**: Reject candidates ending in `/orchestration` as well as `/orchestration/agent` to prevent all doubled-path scenarios.

2. **`registry.rs`**: `resolve_github_token()` now returns a clear error (`bail!`) when an agent exists but is inactive, instead of silently falling back to the global PAT. Unknown agents still fall back for backward compat.

3. **Setup TUI (`step_agents.rs`, `step_existing.rs`, `step_github.rs`)**: All three now search `OPENFLOWS_HOME` for the registry first, falling back to CWD.

## Complements
- #119 — Graceful lore degradation + resolver priority fix
- #120 — Install script and --reset-orchestration registry preservation