### PR TITLE
docs: Clarify Quick Start order — add tenant before starting controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,23 +34,25 @@ cp .env.example .env
 
 This creates admin user in Coder, pushes workspace templates, and verifies LLM/GitHub auth.
 
+### Add a Tenant
+
+```bash
+./scripts/prod.sh tenant owner/repo --name my-team
+```
+
+This binds a GitHub repo to the controller. You must add at least one tenant before starting the controller.
+
 ### Start the Controller
 
 ```bash
 ./scripts/prod.sh run
 ```
 
-This **always** resets Redis to a clean slate, then starts the controller. Create a GitHub issue → OpenFlows automatically assigns, provisions a workspace, and starts working.
+This **always** resets Redis to a clean slate, then starts the controller. Create a GitHub issue in a bound repo → OpenFlows automatically assigns, provisions a workspace, and starts working.
 
 **Monitor:**
 ```bash
 tail -f /tmp/openflows-controller.log
-```
-
-### Add a Tenant
-
-```bash
-./scripts/prod.sh tenant owner/repo --name my-team
 ```
 
 ### Health Check

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,19 +5,11 @@
 All production operations use `./scripts/prod.sh`:
 
 ```bash
+./scripts/prod.sh bootstrap                      # One-time: Setup Coder + push templates
+./scripts/prod.sh tenant owner/repo --name team  # Add a tenant (required before run)
 ./scripts/prod.sh run                            # Start controller (always resets Redis first)
-./scripts/prod.sh bootstrap                      # Setup Coder + push templates
-./scripts/prod.sh tenant owner/repo --name team  # Add a tenant
 ./scripts/prod.sh doctor                         # Health check
 ```
-
-### `run` — Start Controller
-
-```bash
-./scripts/prod.sh run
-```
-
-**Always resets Redis to a clean slate first**, then starts the controller. This ensures no zombie tickets or stale state from previous runs.
 
 ### `bootstrap` — One-time Setup
 
@@ -34,6 +26,16 @@ All production operations use `./scripts/prod.sh`:
 ```bash
 ./scripts/prod.sh tenant owner/repo --name my-team
 ```
+
+Binds a GitHub repo to the controller. **You must add at least one tenant before starting the controller.**
+
+### `run` — Start Controller
+
+```bash
+./scripts/prod.sh run
+```
+
+**Always resets Redis to a clean slate first**, then starts the controller. This ensures no zombie tickets or stale state from previous runs. OpenFlows will process issues in bound repos.
 
 ### `doctor` — Health Check
 
@@ -90,8 +92,8 @@ Controller starts inside workspace
 
 | Command | Description |
 |---------|-------------|
+| `./scripts/prod.sh bootstrap` | One-time: Setup Coder + templates |
+| `./scripts/prod.sh tenant owner/repo --name team` | Add tenant (required before run) |
 | `./scripts/prod.sh run` | Clean slate + start controller |
-| `./scripts/prod.sh bootstrap` | Setup Coder + templates |
-| `./scripts/prod.sh tenant owner/repo --name team` | Add tenant |
 | `./scripts/prod.sh doctor` | Health check |
 | `./scripts/reset-controller-state.sh --confirm` | Clean Redis state |


### PR DESCRIPTION
## Problem

The README Quick Start section was confusing because it presented the steps in the wrong order:

1. Start the Controller (`./scripts/prod.sh run`)
2. Add a Tenant (`./scripts/prod.sh tenant owner/repo --name my-team`)

This made the initial setup appear useless — starting the controller without any registered tenants means it has no work to do. Users couldn't understand why the controller would run without tenants.

## Solution

Reorder the Quick Start section to reflect the correct workflow:

1. **Bootstrap** (one-time setup) — `./scripts/prod.sh bootstrap`
2. **Add a Tenant** (required) — `./scripts/prod.sh tenant owner/repo --name my-team`
3. **Start the Controller** — `./scripts/prod.sh run`

## Changes

- **README.md**: Reordered the Quick Start section with clarifying notes that tenants are required before running the controller
- **scripts/README.md**: Reordered command list and section order to match the proper workflow, with emphasis that tenants must be added before `run`

## Context

This addresses the confusion discovered during testing where `./scripts/prod.sh run` would start with the `default` tenant from `.env`, not the newly added `my-team` tenant. The documentation now makes clear that:

1. Multiple tenants can be added
2. Each tenant requires a separate invocation of `./scripts/prod.sh tenant`
3. The controller then needs to be started

This is also a pointer to issue #139 (Full Multi-Tenancy Implementation) which will allow running multiple tenants concurrently.