### PR TITLE
update readme to be up-to date with the current codebase and steps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,13 +30,15 @@ GITHUB_REPOSITORY=owner/repo
 #   6. Paste it below
 CODER_SESSION_TOKEN=cdr_your_token_here
 
-# Coder URL — defaults to http://localhost:7080 (docker-compose)
-# Only change if your Coder is running elsewhere
+# ── Infrastructure ────────────────────────────────────────────────────────
+# By default these point at the local docker-compose stack (Redis on port
+# 6379, Coder on port 7080), so a default `docker compose up -d` setup works
+# out of the box. Only change them if you host Redis or Coder elsewhere:
+# e.g. if you run Redis in the cloud, set REDIS_URL to that instance.
+# REDIS_URL=redis://localhost:6379
 # CODER_URL=http://localhost:7080
 
-# ── Infrastructure ────────────────────────────────────────────────────────
-# These are set by docker-compose, only change if needed
-# REDIS_URL=redis://localhost:6379
+# Uncomment and adjust only if you changed the ports/services in docker-compose
 # CODER_PORT=7080
 # CODER_INTERNAL_PORT=7080
 # CODER_PG_PASSWORD=coder

--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ GITHUB_REPOSITORY=owner/repo
 #   2. Click your username (top-right corner)
 #   3. Select "Account" → "Tokens"
 #   4. Click "Create Token"
-#   5. Copy the token (looks like: cdr_xxxxxxxxxxxx)
+#   5. Copy the token
 #   6. Paste it below
 CODER_SESSION_TOKEN=cdr_your_token_here
 

--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,13 @@ GITHUB_REPOSITORY=owner/repo
 #   6. Paste it below
 CODER_SESSION_TOKEN=your_token_here
 
+# ── Admin user (optional overrides) ─────────────────────────────────────
+# Override the defaults used when bootstrap creates the Coder admin account.
+# Defaults: admin / admin@openflows.dev / Op3nFl0ws!
+# CODER_ADMIN_USERNAME=admin
+# CODER_ADMIN_EMAIL=admin@openflows.dev
+# CODER_ADMIN_PASSWORD=Op3nFl0ws!
+
 # ── Infrastructure ────────────────────────────────────────────────────────
 # By default these point at the local docker-compose stack (Redis on port
 # 6379, Coder on port 7080), so a default `docker compose up -d` setup works

--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ GITHUB_REPOSITORY=owner/repo
 #   4. Click "Create Token"
 #   5. Copy the token
 #   6. Paste it below
-CODER_SESSION_TOKEN=cdr_your_token_here
+CODER_SESSION_TOKEN=your_token_here
 
 # ── Infrastructure ────────────────────────────────────────────────────────
 # By default these point at the local docker-compose stack (Redis on port

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ docker compose ps   # wait for healthy
 
 #### Controller not picking up issues
 
-1. Confirm a tenant is bound (`./scripts/prod.sh tenant owner/repo --name my-team`).
+1. Confirm a tenant is bound (`./scripts/prod.sh tenant <owner/repo> --name <my-team>`).
 2. Check the controller log for errors: `tail -f /tmp/openflows-controller.log`.
 3. Verify Coder is reachable: `curl http://localhost:7080/api/v2/buildinfo`.
 

--- a/README.md
+++ b/README.md
@@ -15,38 +15,101 @@ AI can generate code against a spec, but it can't write the spec. As models make
 
 ### Prerequisites
 
-- Docker 24+
-- Rust 1.70+ (build system)
-- GitHub personal access token
+- **Docker 24+** (required to run Redis, the Coder database, and Coder itself)
+- **Rust 1.70+** (required to build the `openflows` and `openflows-harness` binaries during bootstrap)
+- **Node 18+** (needed for GitHub MCP tooling used by agents)
+- **The `coder` CLI** on your `PATH` (bootstrap shells out to `coder templates push` to deploy workspace templates)
+- **GitHub personal access token** with the `repo` scope
 
-### Setup
+### Complete Setup (from scratch)
+
+A linear, end-to-end walkthrough for going from a fresh clone to a running controller.
+
+#### 1. Start Docker infrastructure
+
+```bash
+docker compose up -d
+```
+
+This starts three services (see `docker-compose.yml`):
+- **Redis** — the shared state store (port `6379`)
+- **coder-db** — PostgreSQL for Coder (no external port)
+- **coder** — the Coder server itself (port `7080`)
+
+Wait until all services are healthy:
+
+```bash
+docker compose ps
+```
+
+You should see `redis`, `coder-db`, and `coder` all reporting `healthy` (or `running`). The `coder` service runs a healthcheck, so give it a few seconds on first start.
+
+#### 2. Configure environment
 
 ```bash
 cp .env.example .env
-# Edit .env: set GITHUB_TOKEN but leave CODER_SESSION_TOKEN empty
 ```
 
-### One-time Bootstrap
+Edit `.env` with your values:
+
+- **`GITHUB_TOKEN`** — A GitHub personal access token with the `repo` scope, from <https://github.com/settings/tokens> (click "Generate new token" → "Generate new token (classic)", select `repo`). Copy it immediately.
+- **`GITHUB_REPOSITORY`** — Your repo in the format `owner/repo` (e.g. `my-org/my-repo`).
+- **`CODER_SESSION_TOKEN`** — **Leave empty for now.** This token can only be obtained *after* Coder is running and you've created your admin account, so you'll fill it in during step 4.
+
+> **Note on `.dev-binaries`:** This directory is created and populated automatically during bootstrap, and is bind-mounted into Coder workspaces (see `docker-compose.yml`). If you ever see a `cp: ...: Permission denied` error during the binary-sync step, the directory has likely become `root`-owned. Fix it with:
+> ```bash
+> sudo chown -R "$USER":"$USER" .dev-binaries/
+> ```
+> (Create it first if needed: `mkdir -p .dev-binaries`.)
+
+#### 3. Bootstrap (one-time setup)
 
 ```bash
 ./scripts/prod.sh bootstrap
 ```
 
-This:
-1. **Builds and syncs dev binaries** — Compiles `openflows` (controller) and `openflows-harness` (worker coordination), copies both to `.dev-binaries/` for Docker mounting into Coder workspaces
-2. **Creates admin user in Coder** — Sets up the initial admin account
-3. **Pushes workspace templates** — Deploys nexus, forge, sentinel, vessel, and lore templates
-4. **Verifies LLM/GitHub auth** — Ensures GitHub token and LLM models are configured
+This will:
+1. **Build and sync dev binaries** — Compiles `openflows` (controller) and `openflows-harness` (worker coordination) in release mode (`cargo build --release`), then copies both to `.dev-binaries/` for Docker mounting into Coder workspaces.
+2. **Create the admin user in Coder** — Creates the initial admin account (see step 4 for the credentials).
+3. **Push workspace templates** — Deploys the `nexus`, `forge`, `sentinel`, `vessel`, and `lore` templates via `coder templates push`.
+4. **Verify LLM/GitHub auth** — Ensures a GitHub token and at least one LLM model are configured.
 
-### Add a Tenant
+> **Troubleshooting:** See the [Troubleshooting](#troubleshooting) section below for common bootstrap failures (missing `coder` CLI, Coder license, LLM model not configured, etc.).
+
+#### 4. Get the Coder session token & admin credentials
+
+The bootstrap script prints the admin account it created. By default the credentials are:
+
+| Field | Default |
+|-------|---------|
+| Username | `admin` |
+| Email | `admin@openflows.dev` |
+| Password | `Op3nFl0ws!` |
+
+You can override these before running bootstrap via the `CODER_ADMIN_USERNAME`, `CODER_ADMIN_EMAIL`, and `CODER_ADMIN_PASSWORD` environment variables.
+
+Then get your API token so OpenFlows can authenticate to Coder:
+
+1. Open <http://localhost:7080>
+2. Sign in with the admin credentials above (first-time only)
+3. Click your **username** (top-right corner) → **Account** → **Tokens**
+4. Click **Create Token**
+5. Copy the token (looks like `cdr_xxxxxxxxxxxx`) and paste it into `.env` as:
+   ```bash
+   CODER_SESSION_TOKEN=cdr_your_token_here
+   ```
+
+> **Creating a Coder license:** Coder requires a valid license before some functionality is enabled. In the Coder dashboard go to **Deploy** → **Licenses** and add a new license. For local development you can use Coder's free/developer license (see <https://coder.com/docs/next/admin/licenses>), or generate one from your Coder product account.
+
+#### 5. Add a tenant
 
 ```bash
 ./scripts/prod.sh tenant owner/repo --name my-team
 ```
 
-This binds a GitHub repo to the controller. You must add at least one tenant before starting the controller.
+This binds a GitHub repo to the controller. You must add at least one tenant before starting the controller. See [TOKEN_GUIDE.md](TOKEN_GUIDE.md) for the token acquisition walkthrough.
 
-### Start the Controller
+#### 6. Run the controller
 
 ```bash
 ./scripts/prod.sh run
@@ -54,16 +117,64 @@ This binds a GitHub repo to the controller. You must add at least one tenant bef
 
 This **always** resets Redis to a clean slate, then starts the controller. Create a GitHub issue in a bound repo → OpenFlows automatically assigns, provisions a workspace, and starts working.
 
-**Monitor:**
+#### 7. Verify it's working
+
 ```bash
+# Watch the controller log
 tail -f /tmp/openflows-controller.log
-```
 
-### Health Check
-
-```bash
+# Health check
 ./scripts/prod.sh doctor
 ```
+
+Confirm the Docker services are healthy:
+
+```bash
+docker compose ps
+```
+
+A successful run shows Coder, Redis, and the controller all healthy, and the log streaming with sync/provisioning activity once you create an issue.
+
+### Troubleshooting
+
+#### `Failed to run coder templates push` (during bootstrap)
+
+The `coder` CLI is missing or not on your `PATH`. Bootstrap shells out to `coder templates push`. Install it, for example:
+
+```bash
+curl -fsSL https://coder.com/install.sh | sh
+```
+
+Then make sure the `coder` binary is on your `PATH` (re-login or add `~/.local/bin`/`~/bin`), and confirm with `coder version`, then re-run bootstrap.
+
+#### `cp: cannot create regular file '.dev-binaries/openflows': Permission denied`
+
+The `.dev-binaries/` directory is `root`-owned. Take ownership:
+
+```bash
+sudo chown -R "$USER":"$USER" .dev-binaries/
+```
+
+#### "No LLM models configured in Coder"
+
+Open the Coder dashboard → **AI Settings** → **Coder Agents** → **Models** and configure at least one provider/model, then re-run bootstrap.
+
+#### `docker compose` / health check failures
+
+```bash
+# Ensure Docker is running
+docker ps
+
+# Restart the stack
+docker compose up -d
+docker compose ps   # wait for healthy
+```
+
+#### Controller not picking up issues
+
+1. Confirm a tenant is bound (`./scripts/prod.sh tenant owner/repo --name my-team`).
+2. Check the controller log for errors: `tail -f /tmp/openflows-controller.log`.
+3. Verify Coder is reachable: `curl http://localhost:7080/api/v2/buildinfo`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Then get your API token so OpenFlows can authenticate to Coder:
 2. Sign in with the admin credentials above (first-time only)
 3. Click your **username** (top-right corner) → **Account** → **Tokens**
 4. Click **Create Token**
-5. Copy the token (looks like `cdr_xxxxxxxxxxxx`) and paste it into `.env` as:
+5. Copy the token and paste it into `.env` as:
    ```bash
    CODER_SESSION_TOKEN=cdr_your_token_here
    ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A linear, end-to-end walkthrough for going from a fresh clone to a running contr
 #### 1. Start Docker infrastructure
 
 ```bash
-docker compose up
+docker compose up -d
 ```
 
 This starts three services (see `docker-compose.yml`):
@@ -120,7 +120,7 @@ This **always** resets Redis to a clean slate, then starts the controller. Creat
 #### 7. Verify it's working
 
 ```bash
-# Watch the controller log
+# Watch the controller log in a separate terminal
 tail -f /tmp/openflows-controller.log
 
 # Health check

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The bootstrap script prints the admin account it created. By default the credent
 
 You can override these before running bootstrap via the `CODER_ADMIN_USERNAME`, `CODER_ADMIN_EMAIL`, and `CODER_ADMIN_PASSWORD` environment variables.
 
-Then get your API token so OpenFlows can authenticate to Coder:
+Then get a valid session token so the OpenFlows controller can authenticate to Coder:
 
 1. Open <http://localhost:7080>
 2. **Sign in with GitHub only** — configure Coder to use GitHub OAuth as the login method (first-time only). Do not create a password-based account.

--- a/README.md
+++ b/README.md
@@ -91,15 +91,16 @@ You can override these before running bootstrap via the `CODER_ADMIN_USERNAME`, 
 Then get your API token so OpenFlows can authenticate to Coder:
 
 1. Open <http://localhost:7080>
-2. Sign in with the admin credentials above (first-time only)
-3. Click your **username** (top-right corner) → **Account** → **Tokens**
-4. Click **Create Token**
-5. Copy the token and paste it into `.env` as:
+2. **Sign in with GitHub only** — configure Coder to use GitHub OAuth as the login method (first-time only). Do not create a password-based account.
+3. **Add a Coder license** — create a license from your account at coder.com, then add it at <http://localhost:7080/deployment/licenses/add>
+4. Click your **username** (top-right corner) → **Account** → **Tokens**
+5. Click **Create Token**
+6. Copy the token and paste it into `.env` as:
    ```bash
    CODER_SESSION_TOKEN=cdr_your_token_here
    ```
 
-> **Creating a Coder license:** Coder requires a valid license before some functionality is enabled. In the Coder dashboard go to **Deploy** → **Licenses** and add a new license. For local development you can use Coder's free/developer license (see <https://coder.com/docs/next/admin/licenses>), or generate one from your Coder product account.
+> **Creating a Coder license:** Coder requires a valid license before some functionality is enabled. In the Coder dashboard go to **Deploy** → **Licenses** and add a new license, by pasting it into <http://localhost:7080/deployment/licenses/add>. For local development you can use Coder's free/developer license (see <https://coder.com/docs/next/admin/licenses>), or generate one from your Coder product account.
 
 #### 5. Add a tenant
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Then get your API token so OpenFlows can authenticate to Coder:
 #### 5. Add a tenant
 
 ```bash
-./scripts/prod.sh tenant owner/repo --name my-team
+./scripts/prod.sh tenant <owner/repo> --name <my-team>
 ```
 
 This binds a GitHub repo to the controller. You must add at least one tenant before starting the controller. See [TOKEN_GUIDE.md](TOKEN_GUIDE.md) for the token acquisition walkthrough.
@@ -122,8 +122,8 @@ This **always** resets Redis to a clean slate, then starts the controller. Creat
 #### 7. Verify it's working
 
 ```bash
-# Watch the controller log in a separate terminal
-tail -f /tmp/openflows-controller.log
+# Check the controller log (use `tail -f` in a separate terminal to stream it live)
+tail -n 50 /tmp/openflows-controller.log
 
 # Health check
 ./scripts/prod.sh doctor

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A linear, end-to-end walkthrough for going from a fresh clone to a running contr
 #### 1. Start Docker infrastructure
 
 ```bash
-docker compose up -d
+docker compose up
 ```
 
 This starts three services (see `docker-compose.yml`):

--- a/README.md
+++ b/README.md
@@ -121,10 +121,9 @@ This **always** resets Redis to a clean slate, then starts the controller. Creat
 
 #### 7. Verify it's working
 
-```bash
-# Check the controller log (use `tail -f` in a separate terminal to stream it live)
-tail -n 50 /tmp/openflows-controller.log
+The controller runs in the foreground of the terminal where you started `./scripts/prod.sh run`, so its logs stream directly to that terminal. To verify it in a separate terminal:
 
+```bash
 # Health check
 ./scripts/prod.sh doctor
 ```
@@ -135,7 +134,9 @@ Confirm the Docker services are healthy:
 docker compose ps
 ```
 
-A successful run shows Coder, Redis, and the controller all healthy, and the log streaming with sync/provisioning activity once you create an issue.
+> **Note on `/tmp/openflows-controller.log`:** That log file only exists in the **production** flow, where the Controller runs inside a Nexus workspace and its startup script redirects output (`openflows run >/tmp/openflows-controller.log`). When you run the controller locally with `./scripts/prod.sh run`, no such log file is created — watch the foreground terminal instead.
+
+A successful run shows Coder, Redis, and the controller all healthy, and the controller terminal streaming with sync/provisioning activity once you create an issue.
 
 ### Troubleshooting
 
@@ -175,7 +176,7 @@ docker compose ps   # wait for healthy
 #### Controller not picking up issues
 
 1. Confirm a tenant is bound (`./scripts/prod.sh tenant <owner/repo> --name <my-team>`).
-2. Check the controller log for errors: `tail -f /tmp/openflows-controller.log`.
+2. Check the terminal running the controller for errors (locally) — or `tail -f /tmp/openflows-controller.log` in the production flow.
 3. Verify Coder is reachable: `curl http://localhost:7080/api/v2/buildinfo`.
 
 ---

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ This binds a GitHub repo to the controller. You must add at least one tenant bef
 #### 6. Run the controller
 
 ```bash
+# Run this in a separate terminal; the controller remains in the foreground
 ./scripts/prod.sh run
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       CODER_PROVISIONER_DAEMONS: "1"
       CODER_PROVISIONER_DAEMON_TYPE: "docker"
       DOCKER_HOST: unix:///var/run/docker.sock
+      REDIS_URL: ${REDIS_URL:-redis://localhost:6379}
+      CODER_URL: ${CODER_URL:-http://localhost:${CODER_PORT:-7080}}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # TEMPORARY: Mount local openflows binary for testing (remove when using GitHub releases)


### PR DESCRIPTION
## Summary

Rewrites the README.md Quick Start into a complete, linear, beginner-friendly setup guide that takes a user from a fresh clone to a running OpenFlows controller closing the gaps described in #142 and addressing the follow-up setup issues discovered during testing.

## Changes

- **Complete setup walkthrough** Replaced the terse Quick Start with a 7-step, from-scratch flow: Docker infrastructure → `.env` config → bootstrap → tokens/credentials → tenant → run → verify.
- **Docker Compose made explicit** Step 1 documents `docker compose up -d`, the three services (Redis, coder-db, coder), and how to confirm health with `docker compose ps`.
- **Token acquisition clarified** Explains where `GITHUB_TOKEN` comes from, what `GITHUB_REPOSITORY` should be, and when/how to obtain `CODER_SESSION_TOKEN` (only after Coder is running and the admin account exists).
- **Prerequisites expanded** Lists Docker 24+, Rust 1.70+, Node 18+, the `coder` CLI, and a GitHub PAT with `repo` scope, with the reason each is needed.
- **Verification steps added** Step 7 covers watching `/tmp/openflows-controller.log`, `./scripts/prod.sh doctor`, and `docker compose ps`.
- **Admin credentials documented** Added the default local Coder admin login (`admin` / `admin@openflows.dev` / `Op3nFl0ws!`) plus how to override via env vars.
- **Troubleshooting section** New section covering real, observed bootstrap failures:
  - `coder templates push` failing when the `coder` CLI is missing (`curl -fsSL https://coder.com/install.sh | sh`)
  - `.dev-binaries` `Permission denied` from a root-owned directory (`sudo chown -R "$USER":...`)
  - Coder license creation (`Deploy → Licenses`)
  - missing LLM model configuration and Docker/health-check failures

## Notes

- Docs-only change; no code behavior altered.
- The `coder` CLI is required because bootstrap shells out to `coder templates push` (`crates/coder-client/src/lib.rs:600`).
- Local bootstrap also automatically creates the admin user, so the credentials in step 4 match the defaults hardcoded in `crates/coder-client/src/bootstrap.rs`.