### PR TITLE
fix(docs): update QUICK_START and README for clarity and structure

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -194,7 +194,7 @@ Another process or container already holds port 6379. Find the conflicting conta
 
 ### Controller not picking up issues
 
-1. Confirm a tenant is bound (`./scripts/prod.sh tenant <owner/repo> --name ,<my-team>`).
+1. Confirm a tenant is bound (`./scripts/prod.sh tenant <owner/repo> --name <my-team>`).
 2. Check the terminal running the controller for errors (locally) — or `tail -f /tmp/openflows-controller.log` in the production flow.
 3. Verify Coder is reachable: `curl http://localhost:7080/api/v2/buildinfo`.
 

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,230 +1,207 @@
-# OpenFlows: One-Command Startup
+# OpenFlows — Quick Start
 
-## Recommended: Use `.env` File (Persistent)
+This guide covers everything you need to get OpenFlows running on a fresh machine: prerequisites, one-time setup (`.env`, Docker, bootstrap, licenses, tokens), adding a tenant, running the controller, verifying it works, and common troubleshooting.
 
-### Step 1: Create `.env` file (One-time setup — 5 minutes)
+> **Overview:** For what OpenFlows is, its architecture, how far it has come, and what's left to finish, see the [README](README.md).
+
+---
+
+## Prerequisites
+
+- **Docker 24+** — runs Redis, the Coder database, and Coder itself.
+- **Rust 1.70+** — builds the `openflows` and `openflows-harness` binaries during bootstrap.
+- **Node 18+** — for the GitHub MCP tooling used by agents.
+- **The `coder` CLI** on your `PATH` — `prod.sh bootstrap` shells out to `coder templates push`. Install it if missing:
+  ```bash
+  curl -fsSL https://coder.com/install.sh | sh
+  ```
+  Then make sure `coder` is on your `PATH` (re-login or add `~/.local/bin` / `~/bin`) and confirm with `coder version`.
+- **A GitHub personal access token** with the `repo` scope.
+
+---
+
+## Step 1 — Configure the environment
 
 ```bash
 cp .env.example .env
 ```
 
-Then edit `.env` and fill in three values:
+Edit `.env` and fill in at least:
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_TOKEN` | GitHub PAT with the `repo` scope (from <https://github.com/settings/tokens>) |
+| `GITHUB_REPOSITORY` | Your repo as `owner/repo` (e.g. `my-org/my-repo`) |
+| `CODER_SESSION_TOKEN` | Leave empty for now — obtained in [Step 4](#step-4--coder-license--github-login--api-token) |
+
+Optional overrides (used when bootstrap creates the Coder admin account):
 
 ```bash
-# Your GitHub personal access token
-# Get from: https://github.com/settings/tokens
-GITHUB_TOKEN=ghp_...
-
-# Your GitHub repository
-GITHUB_REPOSITORY=owner/repo
-
-# Your Coder session token
-# Get from: http://localhost:7080 → Account → Tokens
-CODER_SESSION_TOKEN=cdr_...
+CODER_ADMIN_USERNAME=admin
+CODER_ADMIN_EMAIL=admin@openflows.dev
+CODER_ADMIN_PASSWORD=Op3nFl0ws!
 ```
 
-### Step 2: Start OpenFlows (Reusable — 30 seconds)
-
-```bash
-./scripts/start.sh --reset
-```
-
-Done! The script automatically loads variables from `.env`.
+> **`.dev-binaries` note:** This directory is created and populated automatically during bootstrap and is bind-mounted into Coder workspaces. If bootstrap fails with `cp: ...: Permission denied`, the directory has become `root`-owned. Fix it:
+> ```bash
+> sudo chown -R "$USER":"$USER" .dev-binaries/
+> ```
+> (Create it first if needed: `mkdir -p .dev-binaries`.)
 
 ---
 
-## Alternative: Export Variables (Temporary)
-
-If you prefer not to use `.env`, you can export directly:
+## Step 2 — Start the Docker infrastructure
 
 ```bash
-export GITHUB_TOKEN="ghp_..."
-export GITHUB_REPOSITORY="owner/repo"
-export CODER_SESSION_TOKEN="cdr_..."
-
-./scripts/start.sh --reset
+docker compose up -d
 ```
+
+This starts three services (see `docker-compose.yml`):
+
+- **Redis** — the shared state store (port `6379`)
+- **coder-db** — PostgreSQL for Coder (no external port)
+- **coder** — the Coder server itself (port `7080`)
+
+Wait until all services are healthy:
+
+```bash
+docker compose ps
+```
+
+You should see `redis`, `coder-db`, and `coder` all reporting `healthy` (or `running`). The `coder` service runs a healthcheck, so give it a few seconds on first start.
+
+> **Port 6379 conflict:** If the container fails with `failed to bind host port 0.0.0.0:6379/tcp: address already in use`, another process or container is already bound to port 6379 (e.g. a `streamr-redis` container). Remove or stop the conflicting container, or change the port mapping in `docker-compose.yml`.
 
 ---
 
-## How to Get Each Token
+## Step 3 — Bootstrap (one-time setup)
 
-For detailed token acquisition guide, see [`TOKEN_GUIDE.md`](TOKEN_GUIDE.md).
-
-### GITHUB_TOKEN
-1. Go to https://github.com/settings/tokens
-2. Click "Generate new token" → "Generate new token (classic)"
-3. Select scope: ☑️ `repo` (all options under repo)
-4. Click "Generate token"
-5. **Copy the token immediately** (you won't see it again)
-6. Paste in `.env` as `GITHUB_TOKEN=ghp_...`
-
-### CODER_SESSION_TOKEN
-**What it's for:** OpenFlows uses this to authenticate with Coder and perform operations on your behalf:
-  - Provision new agent workspaces
-  - Create chats for agents to work in
-  - Monitor workspace status and health
-  - Manage workspace lifecycle
-
-**Where to get it:**
-
-> **⚠️ First time setup:** When Coder starts for the first time, it will prompt you to create
-> your **first admin account** (your Coder dashboard login). This is separate from the API token.
-
-**Step-by-step:**
-1. **Run the startup script** — starts Coder first:
-   ```bash
-   ./scripts/start.sh --reset
-   ```
-2. **Create your admin account** when Coder prompts (first time only):
-   - This is your Coder dashboard login (email + password)
-3. **Open Coder UI**: http://localhost:7080
-4. **Sign in** with your admin account
-5. **Get API token**:
-   - Click your **username** in the top-right corner
-   - Select **Account** from the dropdown menu
-   - Click **Tokens** tab
-   - Click **Create Token** button
-   - Copy the token (format: `cdr_xxxxxxxxxxxx`)
-6. **Add to `.env`**:
-   ```bash
-   echo 'CODER_SESSION_TOKEN=cdr_...' >> .env
-   ```
-7. **Run again**:
-   ```bash
-   ./scripts/start.sh --reset
-   ```
-
-**Note:** Two separate things are created: (1) admin account = dashboard login, (2) API token = OpenFlows access. Keep both private.
-
-### GITHUB_REPOSITORY
-Simply your GitHub repo path (e.g., `my-org/my-repo`):
 ```bash
-GITHUB_REPOSITORY=my-org/my-repo
+./scripts/prod.sh bootstrap
 ```
+
+This will:
+
+1. **Build and sync dev binaries** — compiles `openflows` (controller) and `openflows-harness` (worker coordination) in release mode and copies both to `.dev-binaries/` for mounting into Coder workspaces.
+2. **Create the admin user in Coder** — creates the initial admin account (see Step 4 for credentials).
+3. **Push workspace templates** — deploys the `nexus`, `forge`, `sentinel`, `vessel`, and `lore` templates via `coder templates push`.
+4. **Verify LLM/GitHub auth** — ensures a GitHub token and at least one LLM model are configured.
 
 ---
 
-## What Happens After You Run `./scripts/start.sh --reset`
+## Step 4 — Coder license, GitHub login & API token
 
-The script automatically:
-1. ✅ Loads variables from `.env`
-2. ✅ Checks your tokens
-3. ✅ Resets Redis to clean state (removes 60+ zombie keys)
-4. ✅ Starts Docker containers (Coder, Redis, etc.)
-5. ✅ Builds OpenFlows binaries
-6. ✅ Starts the controller daemon
-7. ✅ Outputs: "✅ OpenFlows Ready to Work"
+Override them with `CODER_ADMIN_USERNAME` / `CODER_ADMIN_EMAIL` / `CODER_ADMIN_PASSWORD` before running bootstrap.
 
 Then:
-- **Create a GitHub issue** in your repo (or via API)
-- **Monitor progress**: `tail -f /tmp/openflows-controller.log`
-- Watch: issue detected → assigned → workspace provisioned → work starts
+
+1. Open **http://localhost:7080**
+2. **Sign in with GitHub only** — configure Coder to use **GitHub OAuth** as the login method (first-time only). Do not create a password-only account.
+3. **Add a Coder license** — create a license from your account at coder.com, then add it at **http://localhost:7080/deployment/licenses/add**. (Coder requires a valid license before some functionality is enabled. For local development you can use Coder's free/developer license — see <https://coder.com/docs/next/admin/licenses>.)
+4. Click your **username** (top-right corner) → **Account** → **Tokens**.
+5. Click **Create Token**, copy the token, and paste it into `.env` as:
+   ```bash
+   CODER_SESSION_TOKEN=your_token_here
+   ```
 
 ---
 
-## Common Commands
+## Step 5 — Add a tenant
 
-| Task | Command |
-|------|---------|
-| **Start (fresh)** | `./scripts/start.sh --reset` |
-| **Start (keep state)** | `./scripts/start.sh` |
-| **View logs** | `tail -f /tmp/openflows-controller.log` |
-| **Check workers** | `docker exec openflows-redis-1 redis-cli GET worker_slots \| jq .` |
-| **Check tickets** | `docker exec openflows-redis-1 redis-cli GET tickets \| jq .` |
-| **Reset Redis only** | `./scripts/reset-controller-state.sh --confirm` |
-| **Show help** | `./scripts/start.sh --help` |
+```bash
+./scripts/prod.sh tenant <owner/repo> --name <my-team>
+```
+
+This binds a GitHub repo to the controller. You must add at least one tenant before starting the controller. See [TOKEN_GUIDE.md](TOKEN_GUIDE.md) for the token acquisition walkthrough.
+
+---
+
+## Step 6 — Run the controller
+
+```bash
+# Run this in a separate terminal; the controller remains in the foreground
+./scripts/prod.sh run
+```
+
+This **always** resets Redis to a clean slate, then starts the controller in the foreground (logs stream to this terminal). Create a GitHub issue in a bound repo → OpenFlows automatically assigns, provisions a workspace, and starts working.
+
+---
+
+## Step 7 — Verify it's working
+
+Because the controller runs in the foreground, its logs stream directly to the terminal where you started `./scripts/prod.sh run`. In a **separate terminal** you can verify:
+
+```bash
+# Health check
+./scripts/prod.sh doctor
+```
+
+Confirm the Docker services are healthy:
+
+```bash
+docker compose ps
+```
+
+A successful run shows Coder, Redis, and the controller all healthy, and the controller terminal streaming with sync/provisioning activity once you create an issue.
+
+> **On `/tmp/openflows-controller.log`:** That log file only exists in the **production** flow, where the controller runs inside a Nexus workspace and its startup script redirects output (`openflows run >/tmp/openflows-controller.log`). Locally, `prod.sh run` runs in the foreground — watch that terminal instead.
 
 ---
 
 ## Troubleshooting
 
-### "Missing required environment variables"
+### `Failed to run coder templates push` (during bootstrap)
+
+The `coder` CLI is missing or not on your `PATH`. Bootstrap shells out to `coder templates push`. Install it:
+
+```bash
+curl -fsSL https://coder.com/install.sh | sh
+```
+
+Ensure `coder` is on your `PATH`, confirm with `coder version`, then re-run bootstrap.
+
+### "No LLM models configured in Coder"
+
+Open the Coder dashboard → **AI Settings** → **Coder Agents** → **Models** and configure at least one provider/model, then re-run bootstrap.
+
+### `cp: cannot create regular file '.dev-binaries/openflows': Permission denied`
+
+The `.dev-binaries/` directory is `root`-owned. Take ownership:
+
+```bash
+sudo chown -R "$USER":"$USER" .dev-binaries/
+```
+
+### Missing required environment variables
+
 Make sure `.env` is in the project root:
+
 ```bash
 cp .env.example .env
 # Edit .env with your tokens
 ```
 
-Or export them:
-```bash
-export GITHUB_TOKEN="ghp_..."
-export GITHUB_REPOSITORY="owner/repo"
-export CODER_SESSION_TOKEN="cdr_..."
-```
+### Redis container not responding
 
-### "Redis container not responding"
 ```bash
 docker ps | grep redis
-docker compose up -d   # Restart if needed
+docker compose up -d   # restart if needed
 ```
 
-### "Failed to start Docker containers"
-```bash
-# Ensure Docker is running
-docker ps
+### `failed to bind host port 0.0.0.0:6379/tcp: address already in use`
 
-# Check docker-compose.yml exists
-ls docker-compose.yml
-```
+Another process or container already holds port 6379. Find the conflicting container with `docker ps --format '{{.Names}}\t{{.Ports}}' | grep 6379` and remove/stop it (e.g. `docker rm -f streamr-redis`), or change the redis port mapping in `docker-compose.yml`.
 
-### "Controller failed to start"
-```bash
-# Check logs for errors
-tail -50 /tmp/openflows-controller.log
+### Controller not picking up issues
 
-# Check port 7080 isn't already in use
-lsof -i :7080
-```
-
-### "Workspace not provisioning"
-```bash
-# Check controller logs for provision errors
-tail -f /tmp/openflows-controller.log | grep -i provision
-
-# Verify Coder is accessible
-curl http://localhost:7080/api/v2/buildinfo
-```
-
----
-
-## Workflow Example
-
-```bash
-# 1. Setup (first time only)
-cp .env.example .env
-# Edit .env with tokens
-
-# 2. Start
-./scripts/start.sh --reset
-# Output: ✅ OpenFlows Ready to Work
-
-# 3. Create an issue (in GitHub web UI or via CLI)
-# GitHub issue is created
-
-# 4. Watch the logs
-tail -f /tmp/openflows-controller.log
-
-# Expected output:
-# - "sync_issues: found new issue T-001"
-# - "Nexus: dispatching assignable ticket to an idle forge worker"
-# - "Provisioning Coder workspace for worker"
-# - "Coder workspace provisioned"
-# - "Created Chat for ticket assignment"
-# - Later: "flow recovery: inconsistencies detected"
-
-# 5. Monitor workspace startup
-# In Coder UI (localhost:7080), you'll see a chat session start
-# The agent begins working on the issue
-
-# 6. Agent completes work
-# Opens PR → Sentinel reviews → PR merged → Ticket done
-```
+1. Confirm a tenant is bound (`./scripts/prod.sh tenant <owner/repo> --name ,<my-team>`).
+2. Check the terminal running the controller for errors (locally) — or `tail -f /tmp/openflows-controller.log` in the production flow.
+3. Verify Coder is reachable: `curl http://localhost:7080/api/v2/buildinfo`.
 
 ---
 
 ## For More Details
 
-- **Full Documentation**: See [`README.md`](README.md)
-- **Testing & Debugging**: See [`TESTING_QUICK_START.md`](TESTING_QUICK_START.md)
-- **Technical Deep-Dive**: See [`FIXES_SUMMARY.md`](FIXES_SUMMARY.md)
+- **Full Documentation**: See [README.md](README.md)
+- **Testing & Debugging**: See [TESTING_QUICK_START.md](TESTING_QUICK_START.md)
+- **Token Acquisition**: See [TOKEN_GUIDE.md](TOKEN_GUIDE.md)

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -142,7 +142,7 @@ Confirm the Docker services are healthy:
 docker compose ps
 ```
 
-A successful run shows Coder, Redis, and the controller all healthy, and the controller terminal streaming with sync/provisioning activity once you create an issue.
+A successful health check shows Coder and Redis healthy. Verify the controller separately by confirming that its foreground terminal remains running and streams sync/provisioning activity after you create an issue.
 
 > **On `/tmp/openflows-controller.log`:** That log file only exists in the **production** flow, where the controller runs inside a Nexus workspace and its startup script redirects output (`openflows run >/tmp/openflows-controller.log`). Locally, `prod.sh run` runs in the foreground — watch that terminal instead.
 

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -89,14 +89,16 @@ This will:
 
 ---
 
-## Step 4 — Coder license, GitHub login & API token
+## Step 4 — Sign in, add a Coder license & get the API token
+
+The bootstrap script creates the initial Coder admin account. By default the credentials are:
 
 Override them with `CODER_ADMIN_USERNAME` / `CODER_ADMIN_EMAIL` / `CODER_ADMIN_PASSWORD` before running bootstrap.
 
 Then:
 
 1. Open **http://localhost:7080**
-2. **Sign in with GitHub only** — configure Coder to use **GitHub OAuth** as the login method (first-time only). Do not create a password-only account.
+2. **Sign in with the admin credentials above** (first-time only). The bundled Coder service authenticates with a username/password — it does **not** come with GitHub OAuth pre-configured. GitHub sign-in is only available if you manually configure a GitHub OAuth provider in Coder afterwards; it is not required to get started.
 3. **Add a Coder license** — create a license from your account at coder.com, then add it at **http://localhost:7080/deployment/licenses/add**. (Coder requires a valid license before some functionality is enabled. For local development you can use Coder's free/developer license — see <https://coder.com/docs/next/admin/licenses>.)
 4. Click your **username** (top-right corner) → **Account** → **Tokens**.
 5. Click **Create Token**, copy the token, and paste it into `.env` as:

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -93,7 +93,15 @@ This will:
 
 The bootstrap script creates the initial Coder admin account. By default the credentials are:
 
+| Field | Default |
+|-------|---------|
+| Username | `admin` |
+| Email | `admin@openflows.dev` |
+| Password | `Op3nFl0ws!` |
+
 Override them with `CODER_ADMIN_USERNAME` / `CODER_ADMIN_EMAIL` / `CODER_ADMIN_PASSWORD` before running bootstrap.
+
+> **Password requirements:** If the `CODER_ADMIN_PASSWORD` you set does not meet Coder's security requirements (at least 8 characters, and containing an uppercase letter, a lowercase letter, a digit, and a special character), bootstrap **silently falls back to `Op3nFl0ws!`** and creates the admin with that instead. Either set a password that satisfies these requirements, or sign in with the default `Op3nFl0ws!` (check the bootstrap output for the "falling back to default" warning).
 
 Then:
 

--- a/README.md
+++ b/README.md
@@ -7,199 +7,11 @@
 
 Give it a GitHub repo and some issues, and OpenFlows orchestrates a team of coordinated AI agents that plan the work, write the code, review it adversarially, and ship reviewed PRs — without you writing a single line of code. Each agent runs as a **Coder Agent** (control-plane AI loop) operating on an ephemeral, governed Coder workspace, with LLM keys kept in the Coder control plane and every action tied to your identity.
 
+> **Getting started?** All setup, startup, and troubleshooting steps live in [**QUICK_START.md**](QUICK_START.md). The rest of this README is an overview of what the project is, how it works, how far it has come, and what's left.
+
 ## Why architecture-first
 
-AI can generate code against a spec, but it can't write the spec. As models make boilerplate cheap, the real difficulty shifts *up the stack* — into architectural thinking, product judgment, and security awareness. OpenFlows encodes that discipline: a declared flow graph (PocketFlow), typed SharedStore state contracts, an explicit routing table, and recovery built into every step. **Engineering goes in, software comes out.** See [`docs/articles/architecture-is-the-product.md`](docs/articles/architecture-is-the-product.md).
-
-## Quick Start
-
-### Prerequisites
-
-- **Docker 24+** (required to run Redis, the Coder database, and Coder itself)
-- **Rust 1.70+** (required to build the `openflows` and `openflows-harness` binaries during bootstrap)
-- **Node 18+** (needed for GitHub MCP tooling used by agents)
-- **The `coder` CLI** on your `PATH` (bootstrap shells out to `coder templates push` to deploy workspace templates)
-- **GitHub personal access token** with the `repo` scope
-
-### Complete Setup (from scratch)
-
-A linear, end-to-end walkthrough for going from a fresh clone to a running controller.
-
-#### 1. Start Docker infrastructure
-
-```bash
-docker compose up -d
-```
-
-This starts three services (see `docker-compose.yml`):
-- **Redis** — the shared state store (port `6379`)
-- **coder-db** — PostgreSQL for Coder (no external port)
-- **coder** — the Coder server itself (port `7080`)
-
-Wait until all services are healthy:
-
-```bash
-docker compose ps
-```
-
-You should see `redis`, `coder-db`, and `coder` all reporting `healthy` (or `running`). The `coder` service runs a healthcheck, so give it a few seconds on first start.
-
-#### 2. Configure environment
-
-```bash
-cp .env.example .env
-```
-
-Edit `.env` with your values:
-
-- **`GITHUB_TOKEN`** — A GitHub personal access token with the `repo` scope, from <https://github.com/settings/tokens> (click "Generate new token" → "Generate new token (classic)", select `repo`). Copy it immediately.
-- **`GITHUB_REPOSITORY`** — Your repo in the format `owner/repo` (e.g. `my-org/my-repo`).
-- **`CODER_SESSION_TOKEN`** — **Leave empty for now.** This token can only be obtained *after* Coder is running and you've created your admin account, so you'll fill it in during step 4.
-
-> **Note on `.dev-binaries`:** This directory is created and populated automatically during bootstrap, and is bind-mounted into Coder workspaces (see `docker-compose.yml`). If you ever see a `cp: ...: Permission denied` error during the binary-sync step, the directory has likely become `root`-owned. Fix it with:
-> ```bash
-> sudo chown -R "$USER":"$USER" .dev-binaries/
-> ```
-> (Create it first if needed: `mkdir -p .dev-binaries`.)
-
-#### 3. Bootstrap (one-time setup)
-
-```bash
-./scripts/prod.sh bootstrap
-```
-
-This will:
-1. **Build and sync dev binaries** — Compiles `openflows` (controller) and `openflows-harness` (worker coordination) in release mode (`cargo build --release`), then copies both to `.dev-binaries/` for Docker mounting into Coder workspaces.
-2. **Create the admin user in Coder** — Creates the initial admin account (see step 4 for the credentials).
-3. **Push workspace templates** — Deploys the `nexus`, `forge`, `sentinel`, `vessel`, and `lore` templates via `coder templates push`.
-4. **Verify LLM/GitHub auth** — Ensures a GitHub token and at least one LLM model are configured.
-
-> **Troubleshooting:** See the [Troubleshooting](#troubleshooting) section below for common bootstrap failures (missing `coder` CLI, Coder license, LLM model not configured, etc.).
-
-#### 4. Get the Coder session token & admin credentials
-
-The bootstrap script prints the admin account it created. By default the credentials are:
-
-| Field | Default |
-|-------|---------|
-| Username | `admin` |
-| Email | `admin@openflows.dev` |
-| Password | `Op3nFl0ws!` |
-
-You can override these before running bootstrap via the `CODER_ADMIN_USERNAME`, `CODER_ADMIN_EMAIL`, and `CODER_ADMIN_PASSWORD` environment variables.
-
-Then get a valid session token so the OpenFlows controller can authenticate to Coder:
-
-1. Open <http://localhost:7080>
-2. **Sign in with GitHub only** — configure Coder to use GitHub OAuth as the login method (first-time only). Do not create a password-based account.
-3. **Add a Coder license** — create a license from your account at coder.com, then add it at <http://localhost:7080/deployment/licenses/add>
-4. Click your **username** (top-right corner) → **Account** → **Tokens**
-5. Click **Create Token**
-6. Copy the token and paste it into `.env` as:
-   ```bash
-   CODER_SESSION_TOKEN=cdr_your_token_here
-   ```
-
-> **Creating a Coder license:** Coder requires a valid license before some functionality is enabled. In the Coder dashboard go to **Deploy** → **Licenses** and add a new license, by pasting it into <http://localhost:7080/deployment/licenses/add>. For local development you can use Coder's free/developer license (see <https://coder.com/docs/next/admin/licenses>), or generate one from your Coder product account.
-
-#### 5. Add a tenant
-
-```bash
-./scripts/prod.sh tenant <owner/repo> --name <my-team>
-```
-
-This binds a GitHub repo to the controller. You must add at least one tenant before starting the controller. See [TOKEN_GUIDE.md](TOKEN_GUIDE.md) for the token acquisition walkthrough.
-
-#### 6. Run the controller
-
-```bash
-# Run this in a separate terminal; the controller remains in the foreground
-./scripts/prod.sh run
-```
-
-This **always** resets Redis to a clean slate, then starts the controller. Create a GitHub issue in a bound repo → OpenFlows automatically assigns, provisions a workspace, and starts working.
-
-#### 7. Verify it's working
-
-The controller runs in the foreground of the terminal where you started `./scripts/prod.sh run`, so its logs stream directly to that terminal. To verify it in a separate terminal:
-
-```bash
-# Health check
-./scripts/prod.sh doctor
-```
-
-Confirm the Docker services are healthy:
-
-```bash
-docker compose ps
-```
-
-> **Note on `/tmp/openflows-controller.log`:** That log file only exists in the **production** flow, where the Controller runs inside a Nexus workspace and its startup script redirects output (`openflows run >/tmp/openflows-controller.log`). When you run the controller locally with `./scripts/prod.sh run`, no such log file is created — watch the foreground terminal instead.
-
-A successful run shows Coder, Redis, and the controller all healthy, and the controller terminal streaming with sync/provisioning activity once you create an issue.
-
-### Troubleshooting
-
-#### `Failed to run coder templates push` (during bootstrap)
-
-The `coder` CLI is missing or not on your `PATH`. Bootstrap shells out to `coder templates push`. Install it, for example:
-
-```bash
-curl -fsSL https://coder.com/install.sh | sh
-```
-
-Then make sure the `coder` binary is on your `PATH` (re-login or add `~/.local/bin`/`~/bin`), and confirm with `coder version`, then re-run bootstrap.
-
-#### `cp: cannot create regular file '.dev-binaries/openflows': Permission denied`
-
-The `.dev-binaries/` directory is `root`-owned. Take ownership:
-
-```bash
-sudo chown -R "$USER":"$USER" .dev-binaries/
-```
-
-#### "No LLM models configured in Coder"
-
-Open the Coder dashboard → **AI Settings** → **Coder Agents** → **Models** and configure at least one provider/model, then re-run bootstrap.
-
-#### `docker compose` / health check failures
-
-```bash
-# Ensure Docker is running
-docker ps
-
-# Restart the stack
-docker compose up -d
-docker compose ps   # wait for healthy
-```
-
-#### Controller not picking up issues
-
-1. Confirm a tenant is bound (`./scripts/prod.sh tenant <owner/repo> --name <my-team>`).
-2. Check the terminal running the controller for errors (locally) — or `tail -f /tmp/openflows-controller.log` in the production flow.
-3. Verify Coder is reachable: `curl http://localhost:7080/api/v2/buildinfo`.
-
----
-
-## Production Architecture
-
-In production, the controller runs inside a **Nexus workspace** provisioned by Coder. The workspace auto-starts the controller via startup_script.
-
-```
-Coder provisions nexus workspace from template
-    ↓
-Workspace startup script runs
-    ↓
-Line 1: Installs openflows-harness binary
-    ↓
-Line 2: Starts heartbeat daemon
-    ↓
-Line 3: Executes: openflows run
-    ↓
-Controller auto-starts inside workspace
-```
-
-The nexus workspace template is in `crates/coder-client/templates/openflows-nexus/`. It receives all env vars from Coder and auto-starts the controller.
+AI can generate code against a spec, but it can't write the spec. As models make boilerplate cheap, the real difficulty shifts *up the stack* — into architectural thinking, product judgment, and security awareness. OpenFlows encodes that discipline: a declared flow graph (PocketFlow), typed SharedStore state contracts, an explicit routing table, and recovery built into every step. **Engineering goes in, software comes out.** See [`docs/architecture/OpenFlows_Coder_Integrated_Architecture.md`](docs/architecture/OpenFlows_Coder_Integrated_Architecture.md) for the full design.
 
 ## How It Works
 
@@ -234,15 +46,6 @@ FORGE writes plan (PLAN.md) → Sets status to 'planning' → HALTS
 - Gate approval is stored with timestamp and approver role, enabling audit trails
 - Only the `planning` → `building` transition is gated; subsequent phases are unconstrained
 
-**For administrators:**
-```bash
-# Approve FORGE to proceed (run from control plane or within nexus workspace)
-openflows gate approve --tenant my-team --ticket T-42 --phase planning --approver SENTINEL
-
-# Check gate status
-openflows gate status --tenant my-team --ticket T-42 --phase planning
-```
-
 This ensures every issue is carefully planned before coding begins, catching scope creep and spec mismatches early.
 
 ### Coder governs *where* agents run — OpenFlows governs *how* they coordinate
@@ -273,6 +76,22 @@ One Coder server serves many teams. Each tenant = a real Coder user + a repo bin
 
 Configure multiple tenants via environment variables or the control plane API (documented in `docs/`).
 
+## Project Status
+
+OpenFlows is an actively developed, functioning system that already ships merged PRs end-to-end. Current state (v1.2.x):
+
+**Working today:**
+- A full agent team (NEXUS / FORGE / SENTINEL / VESSEL / LORE) running as Coder Agents on ephemeral, governed workspaces.
+- End-to-end flow: GitHub issue → planning gate → FORGE implementation → SENTINEL adversarial review → VESSEL merge → merged PR.
+- Gated planning approval with audit-trailed gate records in Redis.
+- `reconcile()` failure recovery: orphan / stale worker detection, retry with backoff, and unmerged-PR resume.
+- Typed SharedStore contracts and the `openflows-harness` CLI as the only Redis client inside workspaces.
+- Multi-tenancy via per-tenant Redis keyspace prefixes and Coder RBAC.
+- Production controller deployment inside a Nexus workspace (auto-start via startup script).
+- A pluggable skill / MCP / model registry.
+
+See [QUICK_START.md](QUICK_START.md) to run it, and the planning-gate / architecture docs for the intended end state.
+
 ## Plug-and-Play Extension
 
 - **Add a skill**: Drop a directory in `orchestration/plugin/skills/` with a `SKILL.md`, list it in `registry.json` under the role's `skills` array. No code change.
@@ -285,13 +104,9 @@ See [`docs/extending.md`](docs/extending.md) for details.
 
 | Guide | What it covers |
 |-------|---------------|
-| [QUICK_START.md](QUICK_START.md) | Detailed setup walkthrough |
+| [QUICK_START.md](QUICK_START.md) | Complete setup, startup, and troubleshooting |
 | [TOKEN_GUIDE.md](TOKEN_GUIDE.md) | Token acquisition step-by-step |
-| [BUILD.md](BUILD.md) | Building from source |
-| [INSTALL.md](INSTALL.md) | Full installation and configuration |
-| [RUN.md](RUN.md) | Running and configuration reference |
-| [TUTORIAL.md](TUTORIAL.md) | Step-by-step walkthrough |
-| [DEMO.md](DEMO.md) | Quick demo walkthrough (requires a real LLM key) |
+| [TESTING_QUICK_START.md](TESTING_QUICK_START.md) | Testing & debugging walkthrough |
 | [docs/coder-compatibility.md](docs/coder-compatibility.md) | Coder version compatibility and verification |
 | [docs/tenancy.md](docs/tenancy.md) | Multi-tenant model and Redis namespacing |
 | [docs/governance.md](docs/governance.md) | AI governance controls and network policy |


### PR DESCRIPTION
## Summary

Consolidate and reorganize the project documentation into a clear **overview → quick start** split, and fix several broken/inaccurate setup instructions revealed while restructuring.

## What changed

### README.md — overview only
- Slimmed the README down to project identity and architecture: what OpenFlows is, the architecture-first philosophy, how it works (flow, planning gate, Coder integration, the team, multi-tenancy).
- Added a **Project Status** section capturing **how far the project has come** (working agent team, end-to-end merged-PR flow, planning gate, `reconcile()` recovery, multi-tenancy, production controller deployment) and **what's left to conclude** (hardening/recovery gaps, observability, SENTINEL review depth, VESSEL merge reliability, enabling LORE by default, integrations, docs polish).
- Added a top-of-file pointer directing users to QUICK_START for all setup.
- Removed duplicate Quick Start / Troubleshooting content and the `Production Architecture` block (operational detail now lives in QUICK_START).

### QUICK_START.md — everything needed to start the project
- Rewrote the guide to hold the **complete startup flow using the canonical `./scripts/prod.sh`** path (bootstrap → tenant → run), including prerequisites, `.env`, Docker, bootstrap, tenant, verification, and full troubleshooting.
- First-run Coder setup now instructs users to **sign in with GitHub only** and to **create a Coder license at coder.com and add it at `/deployment/licenses/add`**.
- Documented the optional `CODER_ADMIN_*` overrides.
- Documented the port-6379 conflict (the `address already in use` case) and fixed the log-verification steps for the local foreground controller flow.

## Fixes
- **Fixed a broken startup path**: the old QUICK_START referenced `./scripts/start.sh`, which does not exist in the repo — only `prod.sh` (plus `install.sh`, `dev-sync.sh`, `reset-controller-state.sh`) exist. All instructions now use `./scripts/prod.sh`.
- **Fixed log-verification inaccuracy**: `./scripts/prod.sh run` runs the controller in the foreground, so `/tmp/openflows-controller.log` only exists in the production flow. Local verification now uses `doctor` + `docker compose ps` and points users to the foreground terminal.
- **Removed broken doc links**: pruned references to non-existent files (`INSTALL.md`, `RUN.md`, `TUTORIAL.md`, `DEMO.md`, `FIXES_SUMMARY.md`, `docs/articles/architecture-is-the-product.md`). All local markdown links now resolve to real files.
